### PR TITLE
added spell check and font config dependencies

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -139,6 +139,7 @@ modules:
   - name: Gramps
     buildsystem: simple
     ensure-writable:
+      - /app/data/gramps.keys
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
       - python3 setup.py build --build-base=/app

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -24,9 +24,9 @@ modules:
     build-commands:
       - python3 setup.py install --prefix=/app
     sources:
-      - type: archive
-        url: https://github.com/Vayn/python-fontconfig/archive/v0.5.0.tar.gz
-        sha256: da9699cf145e12ad0ddd241ab467ee9f0fcdb2d302b732a5ecf15cb866738961
+      - type: git
+        url: http://deb.debian.org/debian/pool/main/p/python-fontconfig/python-fontconfig_0.5.1.orig.tar.gz
+        sha256: b7cfe366242f83b8cd7175b7d4dd95d19f42d619c58a51914f72b1e741739994
 
   - name: BSDDB3
     subdir: dist

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -25,8 +25,8 @@ modules:
       - python3 setup.py install --prefix=/app
     sources:
       - type: archive
-        url: http://deb.debian.org/debian/pool/main/p/python-fontconfig/python-fontconfig_0.5.1.orig.tar.gz
-        sha256: b7cfe366242f83b8cd7175b7d4dd95d19f42d619c58a51914f72b1e741739994
+        url: https://github.com/ldo/python_fontconfig/archive/v0.7.tar.gz
+        sha256: 44d3f1597afae0720c02d2504105c5c2b074f2e6bc017f3c73fe33559e571e3b
 
   - name: BSDDB3
     subdir: dist

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -17,6 +17,14 @@ finish-args:
 #needs network access for maps
   - --share=network
 modules:
+    #gramps 5.1.3 does not seem to recognize enchant2 included with sdk or platform
+  - name: enchant-ver1
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
+        sha256: bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5
+
   - name: python-fontconfig
     buildsystem: simple
     ensure-writable:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -139,10 +139,8 @@ modules:
   - name: Gramps
     buildsystem: simple
     ensure-writable:
-      - /app/data/gramps.keys
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py build --build-base=/app
       - python3 setup.py install --prefix=/app --exec-prefix=/bin
       - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
       - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -24,7 +24,7 @@ modules:
     build-commands:
       - python3 setup.py install --prefix=/app
     sources:
-      - type: git
+      - type: archive
         url: http://deb.debian.org/debian/pool/main/p/python-fontconfig/python-fontconfig_0.5.1.orig.tar.gz
         sha256: b7cfe366242f83b8cd7175b7d4dd95d19f42d619c58a51914f72b1e741739994
 

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -17,6 +17,17 @@ finish-args:
 #needs network access for maps
   - --share=network
 modules:
+  - name: python-fontconfig
+    build-system: simple
+    ensure-writable:
+      - /lib/python3.8/site-packages/easy-install.pth
+    build-commands:
+      - python3 setup.py install --prefix=/app
+    sources:
+      - type: archive
+        url: https://github.com/Vayn/python-fontconfig/archive/v0.5.0.tar.gz
+        sha256: da9699cf145e12ad0ddd241ab467ee9f0fcdb2d302b732a5ecf15cb866738961
+
   - name: BSDDB3
     subdir: dist
     builddir: true

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -18,7 +18,7 @@ finish-args:
   - --share=network
 modules:
   - name: python-fontconfig
-    build-system: simple
+    buildsystem: simple
     ensure-writable:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -18,12 +18,13 @@ finish-args:
   - --share=network
 modules:
     #gramps 5.1.3 does not seem to recognize enchant2 included with sdk or platform
-#  - name: enchant-ver1
-#    buildsystem: autotools
-#    sources:
-#      - type: archive
-#        url: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
-#        sha256: bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5
+  - name: enchant-ver1
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
+        sha256: bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5
+
   - name: intltool
     buildsystem: autotools
     sources:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -18,12 +18,25 @@ finish-args:
   - --share=network
 modules:
     #gramps 5.1.3 does not seem to recognize enchant2 included with sdk or platform
-  - name: enchant-ver1
+#  - name: enchant-ver1
+#    buildsystem: autotools
+#    sources:
+#      - type: archive
+#        url: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
+#        sha256: bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5
+  - name: intltool
     buildsystem: autotools
     sources:
       - type: archive
-        url: https://github.com/AbiWord/enchant/releases/download/enchant-1-6-1/enchant-1.6.1.tar.gz
-        sha256: bef0d9c0fef2e4e8746956b68e4d6c6641f6b85bd2908d91731efb68eba9e3f5
+        url: https://launchpad.net/intltool/trunk/0.51.0/+download/intltool-0.51.0.tar.gz
+        sha256: 67c74d94196b153b774ab9f89b2fa6c6ba79352407037c8c14d5aeb334e959cd
+
+  - name: gtk-spell
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/gtkspell/files/3.0.10/gtkspell3-3.0.10.tar.xz
+        sha256: b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732
 
   - name: python-fontconfig
     buildsystem: simple


### PR DESCRIPTION
This PR adds the following optional dependencies:
1. enchant version 1 because the Gramps flatpak is having trouble finding the enchant used in the SDK or Platform
2.  a newer version of intltool because the one included in the SDK or Platform is too old.
3.  GTK spell apparently wasn't in the SDK or Platform
4. python-fontconfig