### PR TITLE
restore some sandbox functions and change gexiv2 girdir

### DIFF
--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -9,7 +9,7 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=xdg-pictures
-  - --filesystem=.gramps
+  - --filesystem=~/.gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -9,7 +9,7 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=xdg-pictures
-  - --filesystem=~/.gramps
+  - --filesystem=~/.gramps:create
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -107,7 +107,7 @@ modules:
   - name: gexiv2Dependency
     buildsystem: meson
     config-opts:
-      - -Dpython3_girdir=/app/lib
+      - -Dpython3_girdir=/app/lib/python3.8/site-packages/gi/overrides
     sources:
       - type: archive
         url:  https://download.gnome.org/sources/gexiv2/0.12/gexiv2-0.12.1.tar.xz

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -6,8 +6,10 @@ sdk: org.gnome.Sdk
 command: gramps
 rename-icon: gramps
 finish-args:
-# needs home access to access documents and pictures
-  - --filesystem=home
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-download
+  - --filesystem=xdg-pictures
+  - --persist=.gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -105,7 +105,7 @@ modules:
   - name: gexiv2Dependency
     buildsystem: meson
     config-opts:
-      - -Dpython3_girdir=no
+      - -Dpython3_girdir=/app/lib
     sources:
       - type: archive
         url:  https://download.gnome.org/sources/gexiv2/0.12/gexiv2-0.12.1.tar.xz

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -9,9 +9,7 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=xdg-pictures
-  - --persist=.gramps/
-  - --persist=.gramps/grampsdb/
-  - --filesystem=xdg-data/.gramps/
+  - --filesystem=.gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -9,8 +9,9 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=xdg-pictures
-  - --persist=.gramps
-  - --filesystem=xdg-data/.gramps
+  - --persist=.gramps/
+  - --persist=.gramps/grampsdb/
+  - --filesystem=xdg-data/.gramps/
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -10,6 +10,7 @@ finish-args:
   - --filesystem=xdg-download
   - --filesystem=xdg-pictures
   - --persist=.gramps
+  - --filesystem=xdg-data/.gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui


### PR DESCRIPTION
1.  I removed blanket access to home to restore some of the sandbox, and limited the flatpak to .gramps and xdg-pictures and xdg-download and xdg-pictures.  This prevents the flatpak's sandbox from accessing directories it shouldn't need.  I verified on a VM that users will still be able to access prior family trees if they were installed in .gramps.
2. changed gexiv2 girdir to /app/lib/python3.8/site-packages/gi/overrides which is where the flatpak wants to install overrides anyway.

I posted here for feedback and will post the update to flathub after a day or two if there are no objections from the developers.