### PR TITLE
Update to 5.1.4-1, some dependency and socket removal changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 These are the manifest and data files required to make a Gramps Flatpak
 
 The flatpak is available on flathub at https://flathub.org/apps/details/org.gramps_project.Gramps
-The Gramps flatpak is currently 5.1.3 with the runtimes and dependencies to work independently regardless of the linux distribution.  There are also dependencies for some third party add-ons like Graphview and Network Chart.  Other add-ons might work, you can check if they are installable by using the Prerequisites Checker add-on.
+The Gramps flatpak is currently 5.1.4 with the runtimes and dependencies to work independently regardless of the linux distribution.  There are also dependencies for some third party add-ons like Graphview and Network Chart.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# Gramps Flatpak
+These are the manifest and data files required to make a Gramps Flatpak
+
+The flatpak is available on flathub at https://flathub.org/apps/details/org.gramps_project.Gramps
+The Gramps flatpak is currently 5.1.3 with the runtimes and dependencies to work independently regardless of the linux distribution.  There are also dependencies for some third party add-ons like Graphview and Network Chart.  Other add-ons might work, you can check if they are installable by using the Prerequisites Checker add-on.

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -196,6 +196,7 @@
   <translation type="gettext">gramps</translation>
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2021-07-26" version="5.1.4-1"/>
     <release date="2020-08-12" version="5.1.3"/>
     <release date="2020-01-10" version="5.1.2"/>
     <release date="2019-09-15" version="5.1.1"/>

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -196,7 +196,7 @@
   <translation type="gettext">gramps</translation>
   <content_rating type="oars-1.1"/>
   <releases>
-    <release date="2021-07-26" version="5.1.4-1"/>
+    <release date="2021-07-28" version="5.1.4-1"/>
     <release date="2020-08-12" version="5.1.3"/>
     <release date="2020-01-10" version="5.1.2"/>
     <release date="2019-09-15" version="5.1.1"/>

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -16,6 +16,7 @@ finish-args:
   - --filesystem=home
 # test to see if it needs access to Gnome Platform libraries
   - --filesystem=/usr/lib/x86_64-linux-gnu:ro
+  - --filesystem=/var/lib/flatpak/runtime/:ro
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -6,8 +6,6 @@ sdk: org.gnome.Sdk
 command: gramps
 rename-icon: gramps
 finish-args:
-# for error notifications
-  - --socket=pulseaudio
 # Gramps installs media files from backups to home, so it needs home access for now
 #  - --filesystem=xdg-documents
 #  - --filesystem=xdg-download
@@ -15,14 +13,12 @@ finish-args:
 #  - --filesystem=~/.gramps:create
   - --filesystem=home
 # test to see if it needs access to Gnome Platform libraries
-  - --filesystem=/usr/lib/x86_64-linux-gnu:ro
-  - --filesystem=/var/lib/flatpak/runtime/:ro
+  - --xdg-run=/var/lib/flatpak/runtime/
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui
   - --socket=wayland
   - --socket=fallback-x11
-  - --share=ipc
 #needs network access for maps
   - --share=network
 modules:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -23,7 +23,8 @@ finish-args:
 #needs network access for maps
   - --share=network
 modules:
-# GNU Revision Control System, current 202104
+# librsvg2 is not seen in the platform and requires old, unmaintained binaries.  not sure whether to use.
+# GNU Revision Control System, most recent version as of 202107 is from 202010
   - name: RCSDependency
     buildsystem: autotools
     sources:
@@ -31,15 +32,15 @@ modules:
         url:  http://mirror.keystealth.org/gnu/rcs/rcs-5.10.0.tar.xz
         sha256:  3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5
 
-# PILLOW for cropping images, latex support, and addons; current 202104
+# PILLOW for cropping images, latex support, and addons; most recent version as of 202107 is from 202107
   - name: PILLOWDependency
     buildsystem: simple
     build-commands:
       - python3 setup.py install --prefix=/app
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/21/23/af6bac2a601be6670064a817273d4190b79df6f74d8012926a39bc7aa77f/Pillow-8.2.0.tar.gz
-        sha256:  a787ab10d7bb5494e5f76536ac460741788f1fbce851068d73a87ca7c35fc3e1
+        url:  https://files.pythonhosted.org/packages/8f/7d/1e9c2d8989c209edfd10f878da1af956059a1caab498e5bc34fa11b83f71/Pillow-8.3.1.tar.gz
+        sha256:  2cac53839bfc5cece8fdbe7f084d5e3ee61e1303cccc86511d351adcb9e2c792
 
 # following dependencies are for the GraphView Addon
     # pgi is not maintained as of 2018, github suggests using pygobject instead

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -262,7 +262,7 @@ modules:
     ensure-writable:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - python3 setup.py install --prefix=/app --exec-prefix=xdg-run/usr/lib/x86_64-linux-gnu/
       - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
       - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/
       - install -Dm644 org.gramps_project.Gramps.desktop -t /app/share/applications/

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -17,6 +17,7 @@ finish-args:
 # for gui
   - --socket=wayland
   - --socket=fallback-x11
+  - --share=ipc
 #needs network access for maps
   - --share=network
 modules:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -13,7 +13,7 @@ finish-args:
 #  - --filesystem=~/.gramps:create
   - --filesystem=home
 # test to see if it needs access to Gnome Platform libraries
-  - --filesystem=xdg-run/var/lib/flatpak/runtime/
+  - --filesystem=xdg-run/usr/lib/x86_64-linux-gnu/
   - --filesystem=host
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -262,7 +262,7 @@ modules:
     ensure-writable:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app --exec-prefix=xdg-run/usr/lib/x86_64-linux-gnu/
+      - python3 setup.py install --prefix=/app --exec-prefix=/usr/lib/x86_64-linux-gnu/
       - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
       - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/
       - install -Dm644 org.gramps_project.Gramps.desktop -t /app/share/applications/

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -13,7 +13,7 @@ finish-args:
 #  - --filesystem=~/.gramps:create
   - --filesystem=home
 # test to see if it needs access to Gnome Platform libraries
-  - --xdg-run=/var/lib/flatpak/runtime/
+  - --filesystem=xdg-run/var/lib/flatpak/runtime/
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -248,8 +248,8 @@ modules:
       - install -Dm644 org.gramps_project.Gramps.metainfo.xml -t /app/share/metainfo/
     sources:
       - type: archive
-        url:  https://github.com/gramps-project/gramps/archive/v5.1.3.tar.gz
-        sha256:  91d755b7e407af40ce5ebe24b29baab860bc6e2871ebcbee3f5e109c438df1e8
+        url:  https://github.com/gramps-project/gramps/archive/refs/tags/v5.1.4.tar.gz
+        sha256:  6e64a5c1175a4897256ca9eb73a4b77c8e84ebff020b8668bdc527d6dcd14273
       - type: file
         path:  org.gramps_project.Gramps.desktop
       - type: file

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -14,6 +14,8 @@ finish-args:
 #  - --filesystem=xdg-pictures
 #  - --filesystem=~/.gramps:create
   - --filesystem=home
+# test to see if it needs access to Gnome Platform libraries
+  - --filesystem=/usr/lib/x86_64-linux-gnu:ro
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui
@@ -262,7 +264,7 @@ modules:
     ensure-writable:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app --exec-prefix=/usr/lib/x86_64-linux-gnu
+      - python3 setup.py install --prefix=/app
       - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
       - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/
       - install -Dm644 org.gramps_project.Gramps.desktop -t /app/share/applications/

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -262,7 +262,7 @@ modules:
     ensure-writable:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app --exec-prefix=/bin
+      - python3 setup.py install --prefix=/app
       - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
       - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/
       - install -Dm644 org.gramps_project.Gramps.desktop -t /app/share/applications/

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -262,7 +262,7 @@ modules:
     ensure-writable:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
-      - python3 setup.py install --prefix=/app
+      - python3 setup.py install --prefix=/app --exec-prefix=/usr/lib/x86_64-linux-gnu
       - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
       - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/
       - install -Dm644 org.gramps_project.Gramps.desktop -t /app/share/applications/

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -242,8 +242,6 @@ modules:
       - /lib/python3.8/site-packages/easy-install.pth
     build-commands:
       - python3 setup.py install --prefix=/app --exec-prefix=/usr/lib/x86_64-linux-gnu/
-      - install -Dm644 /app/share/icons/gramps.png -t /app/share/icons/hicolor/48x48/apps/
-      - install -Dm644 /app/share/gramps/images/gramps.svg -t /app/share/icons/hicolor/scalable/apps/
       - install -Dm644 org.gramps_project.Gramps.desktop -t /app/share/applications/
       - install -Dm644 org.gramps_project.Gramps.metainfo.xml -t /app/share/metainfo/
     sources:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -31,13 +31,6 @@ modules:
         url:  http://mirror.keystealth.org/gnu/rcs/rcs-5.10.0.tar.xz
         sha256:  3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5
 
-  - name: librsvgDependency
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url:  https://download-fallback.gnome.org/sources/librsvg/2.51/librsvg-2.51.4.tar.xz
-        sha256:  0b87d61de9b973aac1fdb9583368b9a893e67f5f7cb75c3e8f7de142557aca00
-
 # PILLOW for cropping images, latex support, and addons; most recent version as of 202107 is from 202107
   - name: PILLOWDependency
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -14,6 +14,7 @@ finish-args:
   - --filesystem=home
 # test to see if it needs access to Gnome Platform libraries
   - --filesystem=xdg-run/var/lib/flatpak/runtime/
+  - --filesystem=host
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -23,7 +23,6 @@ finish-args:
 #needs network access for maps
   - --share=network
 modules:
-# librsvg2 is not seen in the platform and requires old, unmaintained binaries.  not sure whether to use.
 # GNU Revision Control System, most recent version as of 202107 is from 202010
   - name: RCSDependency
     buildsystem: autotools
@@ -31,6 +30,13 @@ modules:
       - type: archive
         url:  http://mirror.keystealth.org/gnu/rcs/rcs-5.10.0.tar.xz
         sha256:  3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5
+
+  - name: librsvgDependency
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url:  https://download-fallback.gnome.org/sources/librsvg/2.51/librsvg-2.51.4.tar.xz
+        sha256:  0b87d61de9b973aac1fdb9583368b9a893e67f5f7cb75c3e8f7de142557aca00
 
 # PILLOW for cropping images, latex support, and addons; most recent version as of 202107 is from 202107
   - name: PILLOWDependency


### PR DESCRIPTION
1.Readme updated to 5.1.4, along with removing mention of Prerequisites Checker due to the add-on not looking in the right place for dependencies included with Gnome Platform in flatpak
2.update metainfo to 5.1.4-1 release for flatpak
3.edit manifest, as follows
-remove pulseaudio socket due to not noticing sounds
-remove ipc socket (meant for more intensive xorg apps)
-update Pillow dependency to 8.3.1
-switch to pyenchant from enchant-1 to provide python bindings in effort to get enchant provided by Gnome Platform in flatpak recognized by Gramps
-remove the move of icons since placement was fixed
-update Gramps to 5.1.4
-point the exec-prefex for the install of Gramps to the directory that gets mounted by the flatpak /usr/lib/x86_64-linux-gnu/ for Gnome Platform in effort to get Gramps to look at the dependencies packaged there.