### PR TITLE
2nd attempt at 5.1.5-4 flatpak

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,8 @@
 Gramps flatpak 5.1.5-4
   - remove old code and comments
   - update geocode-glib sha256sum because the dependency changed upstream
-  - change "no-debuginfo: true" to "strip: true" to make flatpak smaller
+  - update ghostscript dependency to 9.56.1 in hopes compile error was resolved upstream
+  - comment out build-options in hopes they are no longer necessary with the Ghostscript update
   
 Gramps flatpak 5.1.5-3
   - gasinvein added cleanup to make flatpak smaller

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,0 +1,19 @@
+Gramps flatpak 5.1.5-4
+  - remove old code and comments
+  - update geocode-glib sha256sum because the dependency changed upstream
+  - change "no-debuginfo: true" to "strip: true" to make flatpak smaller
+  
+Gramps flatpak 5.1.5-3
+  - gasinvein added cleanup to make flatpak smaller
+  
+Gramps flatpak 5.1.5-2
+  - update to Gnome Platform 42 from 40
+  - change url for rcs
+  - change python 3.8 references to 3.9
+  
+Gramps flatpak 5.1.5-1
+  - update Gramps to 5.1.5
+  - remove submodule folder to get back with gramps-project upstream flatpak
+  - revert to Gnome Platform 40 from 41 due to bug with the use of python in 41
+  - set most modules to pip from setup.py 
+  - set "no-debuginfo: true" to prevent intermittent compiling problem

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,6 +203,7 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2022-06-02" version="5.1.5-4"/>
     <release date="2022-05-05" version="5.1.5-3"/>
     <release date="2022-04-25" version="5.1.5-2"/>
     <release date="2022-02-05" version="5.1.5"/>

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,6 +203,7 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2022-05-25" version="5.1.5-4"/>
     <release date="2022-05-05" version="5.1.5-3"/>
     <release date="2022-04-25" version="5.1.5-2"/>
     <release date="2022-02-05" version="5.1.5"/>

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -167,14 +167,13 @@ modules:
         sha256:  ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5
 
     # Gramps does not see geocodeglib in platform, needed for place coordinate addon
-    # appears to not have versioned releases anymore, last git edit as of 202110 was from 202109
-    # geocodeglib appears to have changed prerequisites and needs to be commented out for now to allow Gramps to compile
+    # appears to not have versioned releases anymore, last git edit as of 202205 was from 202205
   - name: geocodeglibDependency
     buildsystem: meson
     sources:
       - type: archive
         url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/master/geocode-glib-master.tar.gz
-        sha256:  d2cfc8b096f112ad2446278e19473d316a048ed457f6349a05e68cc128a57f2d
+        sha256:  0d4c1bd9997dc0982e4e0a884067e4c4a1675d7cb51dd8205aba74dd02ed0342
 
     # pyicu most recent release as of 202104 was from 202104
   - name: PyICUDependency

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -6,9 +6,6 @@ sdk: org.gnome.Sdk
 command: gramps
 rename-icon: gramps
 rename-desktop-file: gramps.desktop
-# no-debuginfo to prevent Github Actions workflow from getting stuck, it causes errors
-# build-options:
-#  strip: true
 finish-args:
 # Gramps installs media files from backups to home, so it needs home access for now
 #  - --filesystem=xdg-documents

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -170,14 +170,13 @@ modules:
         sha256:  ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5
 
     # Gramps does not see geocodeglib in platform, needed for place coordinate addon
-    # appears to not have versioned releases anymore, last git edit as of 202110 was from 202109
-    # geocodeglib appears to have changed prerequisites and needs to be commented out for now to allow Gramps to compile
+    # appears to not have versioned releases anymore, last git edit as of 202205 was from 202205
   - name: geocodeglibDependency
     buildsystem: meson
     sources:
       - type: archive
         url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/master/geocode-glib-master.tar.gz
-        sha256:  d2cfc8b096f112ad2446278e19473d316a048ed457f6349a05e68cc128a57f2d
+        sha256:  0d4c1bd9997dc0982e4e0a884067e4c4a1675d7cb51dd8205aba74dd02ed0342
 
     # pyicu most recent release as of 202104 was from 202104
   - name: PyICUDependency

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -239,9 +239,6 @@ modules:
 # Gramps
   - name: Gramps
     buildsystem: simple
-    build-options:
-      env:
-        GRAMPS_RESOURCES: /app/lib/python3.9/site-packages
     build-commands:
       - python3 setup.py install --prefix=/app
       - install -Dm644 org.gramps_project.Gramps.metainfo.xml -t /app/share/metainfo/


### PR DESCRIPTION
The intermittent ghostscript error happened again with strip: true so the previous attempt to update the flatpak at flathub failed and had to be reverted.  In the hopes that the intermittent issue was resolved upstream, I updated ghostscript to a newer version.  It has built several times successfully without the error.  I noticed that no build option was 1.6 MB smaller than leaving strip: true in, so I removed the build-options.  This also includes the geocodeglib update that got dropped when reverting, the ChangeLog, etc.