### PR TITLE
update to Gnome 43 platform because 42 is deprecated by flathub

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: InstallFlatpak
       run: |
         sudo add-apt-repository ppa:flatpak/stable
@@ -21,7 +21,7 @@ jobs:
     - name: SetupFlatpak
       run: |
         flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install flathub org.gnome.Platform//42 org.gnome.Sdk//42 -y
+        flatpak install flathub org.gnome.Platform//43 org.gnome.Sdk//43 -y
 
     - name: BuildFlatpak
       run: |
@@ -32,7 +32,7 @@ jobs:
         flatpak build-bundle repo gramps.flatpak org.gramps_project.Gramps
 
     - name: UploadBundle
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: gramps.flatpak
         path: gramps.flatpak

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+Gramps flatpak 5.1.5-5
+  - update runtime to Gnome 43
+  - update hash for geocode-glib due to upstream change
+  - remove gnu rcs
+  
 Gramps flatpak 5.1.5-4
   - remove old code and comments
   - update geocode-glib sha256sum because the dependency changed upstream

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,6 +203,7 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2023-03-25" version="5.1.5-5"/>
     <release date="2022-06-02" version="5.1.5-4"/>
     <release date="2022-05-05" version="5.1.5-3"/>
     <release date="2022-04-25" version="5.1.5-2"/>

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -1,7 +1,7 @@
 app-id: org.gramps_project.Gramps
 # flatpak-builder will not take com.gramps-project.Gramps
 runtime: org.gnome.Platform
-runtime-version: '42'
+runtime-version: '43'
 sdk: org.gnome.Sdk
 command: gramps
 rename-icon: gramps
@@ -31,16 +31,6 @@ cleanup:
   - /share/gir-1.0
   - /share/man
 modules:
-# GNU Revision Control System, most recent version as of 202111 is from 202010
-  - name: RCSDependency
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url: https://ftp.gnu.org/gnu/rcs/rcs-5.10.0.tar.xz
-        mirror-urls:
-          - https://gnu.freemirror.org/gnu/rcs/rcs-5.10.0.tar.xz
-        sha256:  3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5
-
 # PILLOW for cropping images, latex support, and addons; most recent version as of 202107 is from 202107
   - name: PILLOWDependency
     buildsystem: simple
@@ -112,7 +102,7 @@ modules:
         commands:
           - cp -p /usr/share/automake-*/config.{sub,guess} dist
 
-   #python3-bsddb deprecated and does not work after python3.9, must use berkeleydb
+   #python3-bsddb 
   - name: python3-bsddb
     buildsystem: simple
     build-options:
@@ -167,13 +157,13 @@ modules:
         sha256:  ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5
 
     # Gramps does not see geocodeglib in platform, needed for place coordinate addon
-    # appears to not have versioned releases anymore, last git edit as of 202205 was from 202205
+    # appears to not have versioned releases anymore, last git edit as of 202303 was from 202208
   - name: geocodeglibDependency
     buildsystem: meson
     sources:
       - type: archive
         url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/master/geocode-glib-master.tar.gz
-        sha256:  0d4c1bd9997dc0982e4e0a884067e4c4a1675d7cb51dd8205aba74dd02ed0342
+        sha256:  9ec6747d31fee70e5b7ede079f63402b67c21c329ade1d8a8ef9c76de5136901
 
     # pyicu most recent release as of 202104 was from 202104
   - name: PyICUDependency


### PR DESCRIPTION
Gramps flatpak 5.1.5-5
  - update runtime to Gnome 43
  - update hash for geocode-glib due to upstream change
  - remove gnu rcs (not necessary any more)
  - edited some outdated comments in yml

The only problem I found with this update is that the Edit Image Exif Metadata addon no longer works with the python 3.10.6 included with the Gnome 43 runtime, but since flathub is deprecating Gnome 42 it shouldn't be used anymore.

There is a bug report at mantis about the flatpak warning for using Gnome 42 on Gramps, so I was going to push this to flathub tomorrow if nobody objects.
https://gramps-project.org/bugs/view.php?id=12861