### PR TITLE
bug fix: allows xdg access to data, config, cache, and create access to ~/.gramps

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Gramps flatpak 5.2.0-1
-  - add file access to xdg-data, xdg-config, xdg-cache, and ~/.gramps
+  - add file access to various data directories used by prior versions and system installs of Gramps
+    this includes ~/.gramps ~/.local/share ~/.config ~/.cache with create option if the respective gramps subdirectory does not yet exist
 
 Gramps flatpak 5.2.0-0
   - update Gramps source to 5.2.0 and update sha256

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://github.com/flathub/org.gramps_project.Gramps
 For security reasons, the flatpak for Gramps 5.2 will lose access to the entire home directory in exchange for xdg access to only Documents, Downloads, and Pictures. If your media directory for Gramps is not in Documents, Downloads, or Pictures, then you can either:
 1. Move your media directory to either Documents, Downloads, or Pictures, and then use the Media Tool in Gramps to change the path so that Gramps can see the media again
 2. Use flatseal (a flatpak permissions app available at flathub) to allow Gramps access to whereever your media directory is located.
+3. If the 5.2 version of Gramps does not show your tree, then close Gramps, open your file browser to the directory that the .gramps file (or .gpkg file if a backup), right click on the file, and select "Open with Gramps". It will take a couple minutes to convert to the 5.2 version, but it should work as long as you make sure the file and all related pictures are in Documents, Pictures, or Downloads.
 
 Also, the old version of Berkeley Database (BSDDB) that was included with the Gramps 5.0 and 5.1 flatpaks will be dropped for 5.2.
 

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -4,6 +4,8 @@ runtime: org.gnome.Platform
 runtime-version: '45'
 sdk: org.gnome.Sdk
 command: gramps
+# to force an archive flatpak to use system locale instead of English. Not needed for flathub packages.
+separate-locales: false
 finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -77,25 +77,12 @@ modules:
         url: https://sourceforge.net/projects/gtkspell/files/3.0.10/gtkspell3-3.0.10.tar.xz
         sha256: b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732
 
-# following dependencies are for images
+# following dependencies are for images and metadata
     # exiv2 most recent version was 2023Nov as of 2024Feb
   - name: exiv2
     buildsystem: cmake-ninja
     config-opts:
-#      - -DCMAKE_INSTALL_PREFIX=/app
-#     - -DALLOW_IN_SOURCE_BUILD=ON
-#      - -DCMAKE_INSTALL_LIBDIR=lib
-#      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-#      - -DExiv2_INCLUDE_DIRS=/app/include
-#      - -DExiv2_LIBRARIES=/app/lib
-#      - -DCMAKE_CXX_FLAGS=-Wno-deprecated
-#      - -DCMAKE_BUILD_TYPE=Release
-#      - -DBUILD_SHARED_LIBS=ON
-#      - -DEXIV2_BUILD_SAMPLES=ON
-#      - -DEXIV2_ENABLE_NLS=OFF
-#      - -DEXIV2_ENABLE_WEBREADY=ON
       - -DEXIV2_ENABLE_BMFF=ON
-#      - -DEXIV2_BUILD_UNIT_TESTS=ON
       - -DEXIV2_ENABLE_INIH=OFF
     builddir: true  
     sources:
@@ -104,13 +91,9 @@ modules:
         sha256: 3078651f995cb6313b1041f07f4dd1bf0e9e4d394d6e2adc6e92ad0b621291fa
 
     # gexiv2 most recent from 2023July as of 2024Feb
+    # gramps apparently needs introspection to use gexiv2
   - name: gexiv2Dependency
     buildsystem: meson
-    config-opts:
-     # gramps apparently needs introspection to use gexiv2
-     # - -Dintrospection=false
-     # - -Dpython3=false
-     # - -Dvapi=false
     build-options:
       env:
         - -PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR=/app/share/gir-1.0


### PR DESCRIPTION
This change allows the Gramps 5.2 flatpak to regain access to to data, config, cache and ~/.gramps so that users can still access their prior databases from earlier versions of Gramps without doing any workarounds. My test of the gramps.flatpak from this workflow was able to access a 5.1.6 flatpak database.

I was hoping to push this to flathub as soon as possible since more users than I expected have had trouble with the restriction to Documents, Downloads, and Pictures in 5.2.0-0 flatpak.

The gramps.flatpak archive at 44 MB was too big to attach (25 MB limit). I will open a new Issue to discuss how to make archives associated with PR's available for others to test.