### PR TITLE
bug fix: 5.2.0-1 allows home access, also changes workflow to compile pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,7 @@
 name: CreateFlatpak
 
 on:
-  push:
-    branches:
-      - 'main'
+  pull-request:
     paths:
       - 'org.gramps_project.Gramps.yml'
   workflow_dispatch:

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Gramps flatpak 5.2.0-1
+  - add file access to xdg-data, xdg-config, xdg-cache, and ~/.gramps
+
 Gramps flatpak 5.2.0-0
   - update Gramps source to 5.2.0 and update sha256
   - remove flatpak's home directory access in favor of xdg access for Docs, Downloads, and Pictures

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
 Gramps flatpak 5.2.0-1
-  - add file access to xdg-data, xdg-config, xdg-cache, and ~/.gramps
+  - restore home directory access due to user data loss, since flathub blocks adequate access to xdg-data, xdg-config, xdg-cache, and ~/.gramps
 
 Gramps flatpak 5.2.0-0
   - update Gramps source to 5.2.0 and update sha256

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ https://github.com/flathub/org.gramps_project.Gramps
 For security reasons, the flatpak for Gramps 5.2 will lose access to the entire home directory in exchange for xdg access to only Documents, Downloads, and Pictures. If your media directory for Gramps is not in Documents, Downloads, or Pictures, then you can either:
 1. Move your media directory to either Documents, Downloads, or Pictures, and then use the Media Tool in Gramps to change the path so that Gramps can see the media again
 2. Use flatseal (a flatpak permissions app available at flathub) to allow Gramps access to whereever your media directory is located.
+3. If the 5.2 version of Gramps does not show your tree, then close Gramps, open your file browser to the directory that the .gramps file (or .gpkg file if a backup), right click on the file, and select "Open with Gramps". It will take a couple minutes to convert to the 5.2 version, but it should work as long as you make sure the file and all related pictures are in Documents, Pictures, or Downloads.
 
 Also, the old version of Berkeley Database (BSDDB) that was included with the Gramps 5.0 and 5.1 flatpaks will be dropped for 5.2.
 

--- a/README.md
+++ b/README.md
@@ -10,12 +10,6 @@ https://github.com/gramps-project/flatpak
 
 https://github.com/flathub/org.gramps_project.Gramps
 
-***Please Note***
-For security reasons, the flatpak for Gramps 5.2 will lose access to the entire home directory in exchange for xdg access to only Documents, Downloads, and Pictures. If your media directory for Gramps is not in Documents, Downloads, or Pictures, then you can either:
-1. Move your media directory to either Documents, Downloads, or Pictures, and then use the Media Tool in Gramps to change the path so that Gramps can see the media again
-2. Use flatseal (a flatpak permissions app available at flathub) to allow Gramps access to whereever your media directory is located.
-3. If the 5.2 version of Gramps does not show your tree, then close Gramps, open your file browser to the directory that the .gramps file (or .gpkg file if a backup), right click on the file, and select "Open with Gramps". It will take a couple minutes to convert to the 5.2 version, but it should work as long as you make sure the file and all related pictures are in Documents, Pictures, or Downloads.
-
 Also, the old version of Berkeley Database (BSDDB) that was included with the Gramps 5.0 and 5.1 flatpaks will be dropped for 5.2.
 
 Please make regular full backups of your important genealogy files, and include any attached media files for your genealogy in your backups for your convenience.

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,6 +203,7 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
+    <release date="2024-03-09" version="5.2.0-1"/>
     <release date="2024-02-24" version="5.2.0-0"/>
     <release date="2023-06-30" version="5.1.6-1"/>
     <release date="2023-03-25" version="5.1.5-5"/>

--- a/org.gramps_project.Gramps.metainfo.xml
+++ b/org.gramps_project.Gramps.metainfo.xml
@@ -203,7 +203,7 @@
 
   <content_rating type="oars-1.1"/>
   <releases>
-    <release date="2024-03-09" version="5.2.0-1"/>
+    <release date="2024-03-11" version="5.2.0-1"/>
     <release date="2024-02-24" version="5.2.0-0"/>
     <release date="2023-06-30" version="5.1.6-1"/>
     <release date="2023-03-25" version="5.1.5-5"/>

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -4,6 +4,8 @@ runtime: org.gnome.Platform
 runtime-version: '45'
 sdk: org.gnome.Sdk
 command: gramps
+# to force an archive flatpak to use system locale instead of English. Not needed for flathub packages.
+separate-locales: false
 finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -77,25 +77,12 @@ modules:
         url: https://sourceforge.net/projects/gtkspell/files/3.0.10/gtkspell3-3.0.10.tar.xz
         sha256: b040f63836b347eb344f5542443dc254621805072f7141d49c067ecb5a375732
 
-# following dependencies are for images
+# following dependencies are for images and metadata
     # exiv2 most recent version was 2023Nov as of 2024Feb
   - name: exiv2
     buildsystem: cmake-ninja
     config-opts:
-#      - -DCMAKE_INSTALL_PREFIX=/app
-#     - -DALLOW_IN_SOURCE_BUILD=ON
-#      - -DCMAKE_INSTALL_LIBDIR=lib
-#      - -DCMAKE_BUILD_TYPE=RelWithDebInfo
-#      - -DExiv2_INCLUDE_DIRS=/app/include
-#      - -DExiv2_LIBRARIES=/app/lib
-#      - -DCMAKE_CXX_FLAGS=-Wno-deprecated
-#      - -DCMAKE_BUILD_TYPE=Release
-#      - -DBUILD_SHARED_LIBS=ON
-#      - -DEXIV2_BUILD_SAMPLES=ON
-#      - -DEXIV2_ENABLE_NLS=OFF
-#      - -DEXIV2_ENABLE_WEBREADY=ON
       - -DEXIV2_ENABLE_BMFF=ON
-#      - -DEXIV2_BUILD_UNIT_TESTS=ON
       - -DEXIV2_ENABLE_INIH=OFF
     builddir: true  
     sources:
@@ -104,13 +91,9 @@ modules:
         sha256: 3078651f995cb6313b1041f07f4dd1bf0e9e4d394d6e2adc6e92ad0b621291fa
 
     # gexiv2 most recent from 2023July as of 2024Feb
+    # gramps apparently needs introspection to use gexiv2
   - name: gexiv2Dependency
     buildsystem: meson
-    config-opts:
-     # gramps apparently needs introspection to use gexiv2
-     # - -Dintrospection=false
-     # - -Dpython3=false
-     # - -Dvapi=false
     build-options:
       env:
         - -PKG_CONFIG_GOBJECT_INTROSPECTION_1_0_GIRDIR=/app/share/gir-1.0

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -12,9 +12,9 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
-  - --filesystem=xdg-data
-  - --filesystem=xdg-config
-  - --filesystem=xdg-cache
+  - --filesystem= ~/.config/gramps
+  - --filesystem=~/.cache/gramps
+  - --filesystem=~/.local/share/gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -12,6 +12,9 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
+  - --filesystem=~/.local/share:create
+  - --filesystem=~/.config:create
+  - --filesystem=~/.cache:create
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -11,17 +11,17 @@ finish-args:
 # for now, flathub rules blocking the data directories prevent users from choosing to go between a flatpak
 # installation and a system installation. This can cause user data loss, even using persist instead of filesystem
 # can cause data loss for users moving from the flatpak to a system install. When flathub changes thier rules, 
-# home access can be removed and the below filesystems permissiong can be used
-#  - --filesystem=xdg-documents
+# home access can be removed and the below filesystems permissions can be used
+#  - --filesystem=xdg-documents:create
 #  - --filesystem=xdg-download
 #  - --filesystem=xdg-pictures
 # for data directories and compatibility with system installs, flathub currently blocks these directories
  # for databases started with 5.1 and earlier
 #  - --filesystem=~/.gramps:create
  # for databases started with 5.2 system installations
-#  - --filesystem=xdg-data
-#  - --filesystem=xdg-config
-#  - --filesystem=xdg-cache
+#  - --filesystem=xdg-data:create
+#  - --filesystem=xdg-config:create
+#  - --filesystem=xdg-cache:create
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -10,7 +10,11 @@ finish-args:
   - --filesystem=xdg-documents
   - --filesystem=xdg-download
   - --filesystem=xdg-pictures
-#  - --filesystem=~/.gramps:create
+# for data directories and backwards compatibility  
+  - --filesystem=~/.gramps:create
+  - --filesystem=xdg-data
+  - --filesystem=xdg-config
+  - --filesystem=xdg-cache
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -7,14 +7,21 @@ command: gramps
 # to force an archive flatpak to use system locale instead of English. Not needed for flathub packages.
 separate-locales: false
 finish-args:
-  - --filesystem=xdg-documents
-  - --filesystem=xdg-download
-  - --filesystem=xdg-pictures
-# for data directories and backwards compatibility  
-  - --filesystem=~/.gramps:create
-  - --filesystem=~/.local/share:create
-  - --filesystem=~/.config:create
-  - --filesystem=~/.cache:create
+  - --filesystem=home
+# for now, flathub rules blocking the data directories prevent users from choosing to go between a flatpak
+# installation and a system installation. This can cause user data loss, even using persist instead of filesystem
+# can cause data loss for users moving from the flatpak to a system install. When flathub changes thier rules, 
+# home access can be removed and the below filesystems permissiong can be used
+#  - --filesystem=xdg-documents
+#  - --filesystem=xdg-download
+#  - --filesystem=xdg-pictures
+# for data directories and compatibility with system installs, flathub currently blocks these directories
+ # for databases started with 5.1 and earlier
+#  - --filesystem=~/.gramps:create
+ # for databases started with 5.2 system installations
+#  - --filesystem=xdg-data
+#  - --filesystem=xdg-config
+#  - --filesystem=xdg-cache
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -12,9 +12,6 @@ finish-args:
   - --filesystem=xdg-pictures
 # for data directories and backwards compatibility  
   - --filesystem=~/.gramps:create
-  - --filesystem= ~/.config/gramps
-  - --filesystem=~/.cache/gramps
-  - --filesystem=~/.local/share/gramps
 # needs to own upstream name
   - --own-name=org.gramps-project.Gramps
 # for gui


### PR DESCRIPTION
1. allows home access to restore access to databases from the 5.1 flatpak and system installations of Gramps
2. adds comments in case flathub allows ~/.gramps, xdg-data, xdg-config, and xdg-cache in the future
3. changes workflow to run on pull requests so that a gramps.flatpak can be made for PR's

