### PR TITLE
6.0.4--2

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 Gramps flatpak 6.0.4--2
   - add python3-keyring for GrampsWeb compatibility
-  - deps for python3-keyring are dbus-python, flit_core, Jeepney, python3-secretstorage, python3-cryptography
+  - deps for python3-keyring are dbus-python, flit_core, Jeepney, python3-secretstorage, python3-cryptography, cffi
 
 Gramps flatpak 6.0.4--1
   - update Gramps source to 6.0.4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 Gramps flatpak 6.0.4--2
   - add python3-keyring for GrampsWeb compatibility
-  - deps for python3-keyring are dbus-python, flit_core, Jeepney, python3-secretstorage, python3-cryptography, cffi
+  - deps for python3-keyring are dbus-python, flit_core, Jeepney, python3-secretstorage, python3-cryptography
 
 Gramps flatpak 6.0.4--1
   - update Gramps source to 6.0.4

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Gramps flatpak 6.0.4--2
+  - add python3-keyring for GrampsWeb compatibility
+  - deps for python3-keyring are dbus-python, flit_core, Jeepney, python3-secretstorage, python3-cryptography
+
 Gramps flatpak 6.0.4--1
   - update Gramps source to 6.0.4
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,9 @@
-Gramps flatpak 6.0.4--2
+Gramps flatpak 6.0.5--2
   - add python3-keyring for GrampsWeb compatibility
   - deps for python3-keyring are dbus-python, flit_core, Jeepney, python3-secretstorage, python3-cryptography
+
+Gramps flatpak 6.0.5--1
+  - update Gramps source to 6.0.5
 
 Gramps flatpak 6.0.4--1
   - update Gramps source to 6.0.4

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Dependencies confirmed in the flatpak platform:
 
 Dependencies added to the flatpak
 - orjson
-- osmgpsmap with its own dependencies
-- graphviz
+- osmgpsmap with its libsoup dependency
+- graphviz and pygraphviz
 - PyICU
 - ghostscript
 - gspell

--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@ Dependencies added to the flatpak
 - geocodeglib
 - goocanvas
 - networkx
-- python3-keyring and the following 5 subdependencies
+- python3-keyring and the following 6 subdependencies
 - dbus-python dependency for KWallet
 - flit_core
 - Jeepney
 - python3-secretstorage
 - python3-cryptography
+- cffi
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github or at the flathub Gramps flatpak github.
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,29 @@
 These are the manifest and data files required to make a Gramps Flatpak
 
 The flatpak is available on flathub at https://flathub.org/apps/details/org.gramps_project.Gramps
-The Gramps flatpak contains dependencies and works with flathub runtimes to work independently regardless of the linux distribution.  There are also dependencies for some third party add-ons like Graphview and Network Chart.
+The Gramps flatpak contains dependencies and works with flathub runtimes to work independently regardless of the linux distribution.
+
+# List of Included Dependencies
+Dependencies confirmed in the flatpak platform:
+- python3
+- gtk
+- pygobject
+- cairo
+- pango
+- pangocairo
+
+Dependencies added to the flatpak
+- orjson
+- osmgpsmap with its own dependencies
+- graphviz
+- PyICU
+- ghostscript
+- gspell
+- pillow
+- exiv2 and gexiv2
+- geocodeglib
+- goocanvas
+- networkx
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github or at the flathub Gramps flatpak github.
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,12 @@ Dependencies added to the flatpak
 - geocodeglib
 - goocanvas
 - networkx
-- python3-keyring and the following 6 subdependencies
+- python3-keyring and the following 5 subdependencies
 - dbus-python dependency for KWallet
 - flit_core
 - Jeepney
 - python3-secretstorage
 - python3-cryptography
-- cffi
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github or at the flathub Gramps flatpak github.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Dependencies added to the flatpak
 - geocodeglib
 - goocanvas
 - networkx
+- python3-keyring and its dbus-python dependency for KWallet
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github or at the flathub Gramps flatpak github.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,12 @@ Dependencies added to the flatpak
 - geocodeglib
 - goocanvas
 - networkx
-- python3-keyring and its dbus-python dependency for KWallet
+- python3-keyring and the following 5 subdependencies
+- dbus-python dependency for KWallet
+- flit_core
+- Jeepney
+- python3-secretstorage
+- python3-cryptography
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github or at the flathub Gramps flatpak github.
 

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -79,7 +79,7 @@ modules:
   - name: Cryptography
     buildsystem: simple
     build-commands:
-      - pip3 install --prefix /app --no-deps cryptography*.whl
+      - pip3 install --no-deps cryptography*.whl
     sources:
       - type: file
         only-arches: [x86_64]
@@ -102,9 +102,9 @@ modules:
   - name: SecretStorage
     buildsystem: simple
     build-commands:
-      - pip3 install --no-build-isolation .
+      - pip3 install --no-deps SecretStorage*.whl
     sources:
-      - type: archive
+      - type: type
         url:  https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
         sha256:  f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99 
   # python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
@@ -242,7 +242,7 @@ modules:
   - name: orjsonDependency
     buildsystem: simple
     build-commands:
-      - pip3 install --prefix /app --no-deps orjson-*.whl
+      - pip3 install --no-deps orjson-*.whl
     sources:
       - type: file
         only-arches: [x86_64]

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -26,8 +26,10 @@ finish-args:
   - --socket=wayland
   - --socket=fallback-x11
   - --share=ipc
-#needs network access for maps
+# needs network access for maps
   - --share=network
+# allow access to Secret Service for GrampsWebAddon
+  - --own-name=org.freedesktop.secrets
 
 build-options:
   env:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -50,9 +50,9 @@ modules:
 # dbus-python most recent version as of 2025.08.20 is 1.4.0 from 2025.03
   - name: dbus-python
     buildsystem: meson
-    sources: archivee
-      - url: https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
-        sha256: da4ee9bbb9eb901d463a7cc9f99dfdbe6c751c8b48b29b78d378985a3c9656ad
+    sources: archive
+      - url:  https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
+        sha256:  da4ee9bbb9eb901d463a7cc9f99dfdbe6c751c8b48b29b78d378985a3c9656ad
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -45,7 +45,7 @@ cleanup:
   - /share/man
 
 modules:
-#python3-keyring for GrampsWeb
+# python3-keyring for GrampsWeb
 # keyring requires dbus-python to use Kwallet as of 2025.08.20
   # dbus-python most recent version as of 2025.08.20 is 1.4.0 from 2025.03
   - name: dbus-python
@@ -54,15 +54,25 @@ modules:
       - type: archive
         url:  https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
         sha256:  da4ee9bbb9eb901d463a7cc9f99dfdbe6c751c8b48b29b78d378985a3c9656ad
-  #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
-  - name: python3-keyring
+  # python3-keyring will not compile without python3-secretstorage, which requires Jeepney and python-cryptography for v3.3.3 as of 2025.08.20
+  # Jeepney most recent version as of 2025.08.20 is v0.9.0 from 2025.02.27
+  - name: Jeepney
     buildsystem: simple
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz
-        sha256:  0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
+        url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
+        sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
+  #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
+#  - name: python3-keyring
+#    buildsystem: simple
+#    build-commands:
+#      - pip3 install --no-build-isolation .
+#    sources:
+#      - type: archive
+#        url:  https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz
+#        sha256:  0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -89,15 +89,6 @@ modules:
         only-arches: [aarch64]
         url:  https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl
         sha256:  5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5
-  # cffi is a dep for python3-secretstorage, which is a dep for python3-keyring, most recent version as of 2025.08.22 is 1.17.1 from 2024.09.24
-  #- name: cffi
-  #  buildsystem: simple
-  #  build-commands:
-  #    - pip3 install --no-build-isolation .
-  #  sources:
-  #    - type: archive
-  #      url:  https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
-  #      sha256:  1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
   # python3-secretstorage is a dep for python3-keyring, most recent version as of 2025.08.22 is 3.3.3 from 2022.08.13
   - name: SecretStorage
     buildsystem: simple
@@ -108,14 +99,14 @@ modules:
         url:  https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
         sha256:  f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99 
   # python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
-#  - name: python3-keyring
-#    buildsystem: simple
-#    build-commands:
-#      - pip3 install --no-build-isolation .
-#    sources:
-#      - type: archive
-#        url:  https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz
-#        sha256:  0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
+  - name: python3-keyring
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz
+        sha256:  0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -66,14 +66,14 @@ modules:
         sha256:  18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
   # python3-keyring will not compile without python3-secretstorage, which requires Jeepney and python-cryptography for v3.3.3 as of 2025.08.20
   # Jeepney most recent version as of 2025.08.20 is v0.9.0 from 2025.02.27
- # - name: Jeepney
- #   buildsystem: simple
- #   build-commands:
- #     - pip3 install --no-build-isolation .
- #   sources:
- #     - type: archive
- #       url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
- #       sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
+  - name: Jeepney
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
+        sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
   #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -75,14 +75,20 @@ modules:
         url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
         sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
   # cryptography dependency for python3-secretstorage dependency for python3-keyring, most recent version as of 2025.08.22 is 45.0.6 from 2025.08.05
+  # cryptography tar for 45.0.6 requires a rust cargo library, so using whl
   - name: Cryptography
     buildsystem: simple
     build-commands:
-      - pip3 install --no-build-isolation .
+      - pip3 install --prefix /app --no-deps cryptography*.whl
     sources:
-      - type: archive
-        url:  https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz
-        sha256:  5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719
+      - type: file
+        only-arches: [x86_64]
+        url:  https://files.pythonhosted.org/packages/55/66/061ec6689207d54effdff535bbdf85cc380d32dd5377173085812565cf38/cryptography-45.0.6-cp37-abi3-manylinux_2_34_x86_64.whl
+        sha256:  eccddbd986e43014263eda489abbddfbc287af5cddfd690477993dbb31e31016
+      - type: file
+        only-arches: [aarch64]
+        url:  https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl
+        sha256:  5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5
   #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -95,7 +95,7 @@ modules:
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
-      - archive
+      - type: archive
         url:  https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
         sha256:  1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
   # python3-secretstorage is a dep for python3-keyring, most recent version as of 2025.08.22 is 3.3.3 from 2022.08.13

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -89,6 +89,15 @@ modules:
         only-arches: [aarch64]
         url:  https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl
         sha256:  5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5
+  # cffi is a dep for python3-secretstorage, which is a dep for python3-keyring, most recent version as of 2025.08.22 is 1.17.1 from 2024.09.24
+  - name: cffi
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - archive
+        url:  https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
+        sha256:  1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
   # python3-secretstorage is a dep for python3-keyring, most recent version as of 2025.08.22 is 3.3.3 from 2022.08.13
   - name: SecretStorage
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -104,7 +104,7 @@ modules:
     build-commands:
       - pip3 install --no-deps SecretStorage*.whl
     sources:
-      - type: type
+      - type: file
         url:  https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
         sha256:  f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99 
   # python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -82,7 +82,7 @@ modules:
       sources:
         - type: archive
           url:  https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz
-          sha256:   5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719
+          sha256:  5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719
   #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -64,7 +64,7 @@ modules:
       - type: archive
         url:  https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
         sha256:  18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
-  # python3-keyring will not compile without python3-secretstorage, which requires Jeepney and python-cryptography for v3.3.3 as of 2025.08.20
+  # Jeepney is a dep for secretstorage which is a dep for python3-keyring
   # Jeepney most recent version as of 2025.08.20 is v0.9.0 from 2025.02.27
   - name: Jeepney
     buildsystem: simple
@@ -89,7 +89,16 @@ modules:
         only-arches: [aarch64]
         url:  https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl
         sha256:  5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5
-  #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
+  # python3-secretstorage is a dep for python3-keyring, most recent version as of 2025.08.22 is 3.3.3 from 2022.08.13
+  - name: SecretStorage
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz
+        sha256:  2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77
+  # python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple
 #    build-commands:

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -74,15 +74,15 @@ modules:
       - type: archive
         url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
         sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
-    # cryptography dependency for python3-secretstorage dependency for python3-keyring, most recent version as of 2025.08.22 is 45.0.6 from 2025.08.05
-    - name: Cryptography
-      buildsystem: simple
-      build-commands:
-        - pip3 install --no-build-isolation .
-      sources:
-        - type: archive
-          url:  https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz
-          sha256:  5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719
+  # cryptography dependency for python3-secretstorage dependency for python3-keyring, most recent version as of 2025.08.22 is 45.0.6 from 2025.08.05
+  - name: Cryptography
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz
+        sha256:  5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719
   #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -253,5 +253,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url: https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.4.tar.gz
-        sha256: d6c894f9660c8c6f3fb63ba7468889abcd6f0a76eee9017582fbde647b92f4b7
+        url: https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.5.tar.gz
+        sha256: 1295fe352669cdf419d762445db1d26ba5492da30c0a78fef278856eda9cc680

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -43,7 +43,16 @@ cleanup:
   - /lib/cmake
   - /share/gir-1.0
   - /share/man
+
 modules:
+#python3-keyring for GrampsWeb
+# keyring requires dbus-python to use Kwallet as of 2025.08.20
+# dbus-python most recent version as of 2025.08.20 is 1.4.0 from 2025.03
+  - name: dbus-python
+    buildsystem: meson
+    sources: archivee
+      - url: https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
+        sha256: da4ee9bbb9eb901d463a7cc9f99dfdbe6c751c8b48b29b78d378985a3c9656ad
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple
@@ -53,8 +62,7 @@ modules:
       - type: archive
         url:  https://files.pythonhosted.org/packages/f3/af/c097e544e7bd278333db77933e535098c259609c4eb3b85381109602fb5b/pillow-11.1.0.tar.gz
         sha256:  368da70808b36d73b4b390a8ffac11069f8a5c85f29eff1f1b01bcf3ef5b2a20
-
-    # Goocanvas is abandoned and the most recent update is from 2021.01.16.
+# Goocanvas is abandoned and the most recent update is from 2021.01.16.
   - name: GoocanvasDependency
     buildsystem: autotools
     config-opts:
@@ -68,16 +76,14 @@ modules:
         sha256:  670a7557fe185c2703a14a07506156eceb7cea3b4bf75076a573f34ac52b401a
       - type: patch
         path: goocanvas-3.0.0-gcc14.patch
-
-    # Gspell most recent version as of 2025.03 was from 2024.09
+# Gspell most recent version as of 2025.03 was from 2024.09
   - name: gspell
     buildsystem: meson
     sources: 
       - type: archive
         url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
         sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a
-
-# following dependencies are for images and metadata
+# following dependencies are for images and metadata related Gramps addons
     # exiv2 most recent version as of 2025.03 was from 2025.02
   - name: exiv2
     buildsystem: cmake-ninja
@@ -89,7 +95,6 @@ modules:
       - type: archive
         url:  https://github.com/Exiv2/exiv2/archive/refs/tags/v0.28.5.tar.gz
         sha256: e1671f744e379a87ba0c984617406fdf8c0ad0c594e5122f525b2fb7c28d394d
-
     # gexiv2 most recent version as of 2025.03 was from 2024.06
     # gramps apparently needs introspection to use gexiv2
   - name: gexiv2Dependency
@@ -102,7 +107,7 @@ modules:
       - type: archive
         url:  https://gitlab.gnome.org/GNOME/gexiv2/-/archive/gexiv2-0.14.3/gexiv2-gexiv2-0.14.3.tar.gz
         sha256:  5a7ea82effa9c812ac1518a1b4a22a15035d721b0b30cd4b8303228fd5b38e3c
-
+# Map related dependencies
    # osmgpsmap dependency 1.2 as of 2023-06 requires libsoup 2.4. 
    # Libsoup 2 is not in Gnome 44 runtime as of 2023-06, so libsoup needs a manual install until
    # osmgpsmap gets updated to use a newer version of libsoup. Latest libsoup 2 is 2.74 from Oct 2022.
@@ -112,7 +117,6 @@ modules:
       - type: archive
         url: https://download.gnome.org/sources/libsoup/2.74/libsoup-2.74.3.tar.xz
         sha256: e4b77c41cfc4c8c5a035fcdc320c7bc6cfb75ef7c5a034153df1413fa1d92f13
-
     # osmgpsmap is abandoned as of 2025.03 so most recent version was from 202102
   - name: osmgpsmapDependency
     buildsystem: autotools
@@ -120,7 +124,6 @@ modules:
       - type: archive
         url:  https://github.com/nzjrs/osm-gps-map/releases/download/1.2.0/osm-gps-map-1.2.0.tar.gz
         sha256:  ddec11449f37b5dffb4bca134d024623897c6140af1f9981a8acc512dbf6a7a5
-
     # Gramps does not see geocodeglib in platform, needed for place coordinate addon
     # appears to not have versioned releases anymore, last git edit as of 2025.03 was from 2024.03
   - name: geocodeglibDependency
@@ -129,8 +132,7 @@ modules:
       - type: archive
         url:  https://gitlab.gnome.org/GNOME/geocode-glib/-/archive/8f1b5a9149156a03f62dfea14780e8fee030506d/geocode-glib-8f1b5a9149156a03f62dfea14780e8fee030506d.tar.gz
         sha256:  f4ea933937633d6e33607945c9ca45070628e8545be0ea502b59f959932e8b26
-
-    # pyicu most recent release as of 2025.03 was from 2024.10
+# pyicu is a recommended dep for Gramps; most recent release as of 2025.03 was from 2024.10
   - name: PyICUDependency
     buildsystem: simple
     build-commands:
@@ -139,16 +141,14 @@ modules:
       - type: archive
         url: https://files.pythonhosted.org/packages/52/21/4e9b0a3ace3027fc63107fa2b5d6e66e321e104da071d787856962fbad52/PyICU-2.14.tar.gz
         sha256: acc7eb92bd5c554ed577249c6978450a4feda0aa6f01470152b3a7b382a02132
-
-    # graphviz most recent version as of 2025.03 from 2024.12
+# graphviz is a recommended dep for Gramps; most recent version as of 2025.03 from 2024.12
   - name: GraphVizDependency
     buildsystem: autotools
     sources:
       - type: archive
         url: https://gitlab.com/api/v4/projects/4207231/packages/generic/graphviz-releases/12.2.1/graphviz-12.2.1.tar.gz
         sha256: 242bc18942eebda6db4039f108f387ec97856fc91ba47f21e89341c34b554df8
-
-    # pygraphviz 1.14 most recent version 2024.09.29 as of 2025.03
+# pygraphviz allows graphviz to work with python; 1.14 most recent version 2024.09.29 as of 2025.03
   - name: PyGraphVizDependency
     buildsystem: simple
     build-commands:
@@ -157,15 +157,13 @@ modules:
       - type: archive
         url: https://github.com/pygraphviz/pygraphviz/archive/refs/tags/pygraphviz-1.14.tar.gz
         sha256:  d9a43f34b920367fa89a2598083b47db42a28078aff7d4e2cb41475137532560
-
-    # ghostscript most recent version as of 2025.03 was from 2025.03
+# ghostscript is recommended for Gramps; most recent version as of 2025.03 was from 2025.03
   - name: GhostscriptDependency
     buildsystem: autotools
     sources:
       - type: archive
         url: https://github.com/ArtifexSoftware/ghostpdl/archive/refs/tags/ghostpdl-10.05.0.tar.gz
         sha256: 8fb8eb3c34646ac7f0287c7673ebbf3928b23e558f421edf4495b9881430a1d4
-
 # for network chart addon
     # networkx most recent stable version as of 2025.03 was from 2024.10
   - name: networkxDependency
@@ -176,7 +174,6 @@ modules:
       - type: archive
         url: https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz
         sha256: 307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1
-
 # Gramps 6 requires orjson to run in flatpak
 # most recent version is from 2025.01 as of 2025.03
   - name: orjsonDependency
@@ -192,7 +189,6 @@ modules:
         only-arches: [aarch64]
         url: https://files.pythonhosted.org/packages/48/b7/2622b29f3afebe938a0a9037e184660379797d5fd5234e5998345d7a5b43/orjson-3.10.15-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
         sha256: dba5a1e85d554e3897fa9fe6fbcff2ed32d55008973ec9a2b992bd9a65d2352d
-
 # Gramps
   - name: Gramps
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -74,6 +74,15 @@ modules:
       - type: archive
         url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
         sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
+    # cryptography dependency for python3-secretstorage dependency for python3-keyring, most recent version as of 2025.08.22 is 45.0.6 from 2025.08.05
+    - name: Cryptography
+      buildsystem: simple
+      build-commands:
+        - pip3 install --no-build-isolation .
+      sources:
+        - type: archive
+          url:  https://files.pythonhosted.org/packages/d6/0d/d13399c94234ee8f3df384819dc67e0c5ce215fb751d567a55a1f4b028c7/cryptography-45.0.6.tar.gz
+          sha256:   5c966c732cf6e4a276ce83b6e4c729edda2df6929083a952cc7da973c539c719
   #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -29,7 +29,7 @@ finish-args:
 # needs network access for maps
   - --share=network
 # allow access to Secret Service for GrampsWebAddon
-  - --own-name=org.freedesktop.secrets
+  - --talk-name=org.freedesktop.secrets
 
 build-options:
   env:
@@ -49,6 +49,7 @@ cleanup:
 modules:
 # python3-keyring for GrampsWeb
 # keyring requires dbus-python to use Kwallet as of 2025.08.20
+  - shared-modules/libsecret/libsecret.json
   # dbus-python most recent version as of 2025.08.20 is 1.4.0 from 2025.03
   - name: dbus-python
     buildsystem: meson

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -50,8 +50,9 @@ modules:
 # dbus-python most recent version as of 2025.08.20 is 1.4.0 from 2025.03
   - name: dbus-python
     buildsystem: meson
-    sources: archive
-      - url:  https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
+    sources:
+      - type: archive
+        url:  https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
         sha256:  da4ee9bbb9eb901d463a7cc9f99dfdbe6c751c8b48b29b78d378985a3c9656ad
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -62,8 +62,8 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/f2/65/b6ba90634c984a4fcc02c7e3afe523fef500c4980fec67cc27536ee50acf/flit_core-3.12.0-py3-none-any.whl
-        sha256:   e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c
+        url:  https://files.pythonhosted.org/packages/69/59/b6fc2188dfc7ea4f936cd12b49d707f66a1cb7a1d2c16172963534db741b/flit_core-3.12.0.tar.gz
+        sha256:  18f63100d6f94385c6ed57a72073443e1a71a4acb4339491615d0f16d6ff01b2
   # python3-keyring will not compile without python3-secretstorage, which requires Jeepney and python-cryptography for v3.3.3 as of 2025.08.20
   # Jeepney most recent version as of 2025.08.20 is v0.9.0 from 2025.02.27
  # - name: Jeepney

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -102,11 +102,11 @@ modules:
   - name: python3-keyring
     buildsystem: simple
     build-commands:
-      - pip3 install --no-build-isolation .
+      - pip3 install --no-deps keyring*.whl
     sources:
-      - type: archive
-        url:  https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz
-        sha256:  0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
+      - type: file
+        url:  https://files.pythonhosted.org/packages/d3/32/da7f44bcb1105d3e88a0b74ebdca50c59121d2ddf71c9e34ba47df7f3a56/keyring-25.6.0-py3-none-any.whl
+        sha256:  552a3f7af126ece7ed5c89753650eec89c7eaae8617d0aa4d9ad2b75111266bd 
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -90,14 +90,14 @@ modules:
         url:  https://files.pythonhosted.org/packages/77/2d/09b097adfdee0227cfd4c699b3375a842080f065bab9014248933497c3f9/cryptography-45.0.6-cp37-abi3-manylinux_2_34_aarch64.whl
         sha256:  5bd6020c80c5b2b2242d6c48487d7b85700f5e0038e67b29d706f98440d66eb5
   # cffi is a dep for python3-secretstorage, which is a dep for python3-keyring, most recent version as of 2025.08.22 is 1.17.1 from 2024.09.24
-  - name: cffi
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-build-isolation .
-    sources:
-      - type: archive
-        url:  https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
-        sha256:  1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
+  #- name: cffi
+  #  buildsystem: simple
+  #  build-commands:
+  #    - pip3 install --no-build-isolation .
+  #  sources:
+  #    - type: archive
+  #      url:  https://files.pythonhosted.org/packages/fc/97/c783634659c2920c3fc70419e3af40972dbaf758daa229a7d6ea6135c90d/cffi-1.17.1.tar.gz
+  #      sha256:  1c39c6016c32bc48dd54561950ebd6836e1670f2ae46128f67cf49e789c52824
   # python3-secretstorage is a dep for python3-keyring, most recent version as of 2025.08.22 is 3.3.3 from 2022.08.13
   - name: SecretStorage
     buildsystem: simple
@@ -105,8 +105,8 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/53/a4/f48c9d79cb507ed1373477dbceaba7401fd8a23af63b837fa61f1dcd3691/SecretStorage-3.3.3.tar.gz
-        sha256:  2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77
+        url:  https://files.pythonhosted.org/packages/54/24/b4293291fa1dd830f353d2cb163295742fa87f179fcc8a20a306a81978b7/SecretStorage-3.3.3-py3-none-any.whl
+        sha256:  f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99 
   # python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -47,13 +47,22 @@ cleanup:
 modules:
 #python3-keyring for GrampsWeb
 # keyring requires dbus-python to use Kwallet as of 2025.08.20
-# dbus-python most recent version as of 2025.08.20 is 1.4.0 from 2025.03
+  # dbus-python most recent version as of 2025.08.20 is 1.4.0 from 2025.03
   - name: dbus-python
     buildsystem: meson
     sources:
       - type: archive
         url:  https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
         sha256:  da4ee9bbb9eb901d463a7cc9f99dfdbe6c751c8b48b29b78d378985a3c9656ad
+  #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
+  - name: python3-keyring
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/70/09/d904a6e96f76ff214be59e7aa6ef7190008f52a0ab6689760a98de0bf37d/keyring-25.6.0.tar.gz
+        sha256:  0b39998aa941431eb3d9b0d4b2460bc773b9df6fed7621c2dfb291a7e0187a66
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -54,16 +54,26 @@ modules:
       - type: archive
         url:  https://gitlab.freedesktop.org/dbus/dbus-python/-/archive/dbus-python-1.4.0/dbus-python-dbus-python-1.4.0.tar.gz
         sha256:  da4ee9bbb9eb901d463a7cc9f99dfdbe6c751c8b48b29b78d378985a3c9656ad
-  # python3-keyring will not compile without python3-secretstorage, which requires Jeepney and python-cryptography for v3.3.3 as of 2025.08.20
-  # Jeepney most recent version as of 2025.08.20 is v0.9.0 from 2025.02.27
-  - name: Jeepney
+  # flit_core is a dependency for Jeepney which is a dep for python3-secretstorage, which is a dep for python3-keyring
+  # flit_core most recent version as of 2025.08.21 is v3.12.0 from 2025.03.25
+  - name: flit_core
     buildsystem: simple
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
       - type: archive
-        url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
-        sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
+        url:  https://files.pythonhosted.org/packages/f2/65/b6ba90634c984a4fcc02c7e3afe523fef500c4980fec67cc27536ee50acf/flit_core-3.12.0-py3-none-any.whl
+        sha256:   e7a0304069ea895172e3c7bb703292e992c5d1555dd1233ab7b5621b5b69e62c
+  # python3-keyring will not compile without python3-secretstorage, which requires Jeepney and python-cryptography for v3.3.3 as of 2025.08.20
+  # Jeepney most recent version as of 2025.08.20 is v0.9.0 from 2025.02.27
+ # - name: Jeepney
+ #   buildsystem: simple
+ #   build-commands:
+ #     - pip3 install --no-build-isolation .
+ #   sources:
+ #     - type: archive
+ #       url:  https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz
+ #       sha256:   cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
   #python3-keyring most recent version as of 2025.08.20 is v25.6.0 from 2024.12.25
 #  - name: python3-keyring
 #    buildsystem: simple


### PR DESCRIPTION
1. to remember Gramps Web logins, this update adds python3-keyring and 5 dependencies to make keyring work
2. the packaged dependencies have been listed in the README
3. notes in the manifest got edited to remind me why certain dependencies are there