### PR TITLE
6.1.0-beta1--1

### DIFF
--- a/.github/workflows/for.arm.flatpaks.yml
+++ b/.github/workflows/for.arm.flatpaks.yml
@@ -22,7 +22,7 @@ jobs:
     - name: SetupFlatpak
       run: |
         flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49 -y
+        flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//50 -y
 
     - name: BuildFlatpak
       run: |

--- a/.github/workflows/for.arm.flatpaks.yml
+++ b/.github/workflows/for.arm.flatpaks.yml
@@ -22,7 +22,7 @@ jobs:
     - name: SetupFlatpak
       run: |
         flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//50 -y
+        flatpak install flathub org.gnome.Platform//50 org.gnome.Sdk//50 -y
 
     - name: BuildFlatpak
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     - name: SetupFlatpak
       run: |
         flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//49 -y
+        flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//50 -y
 
     - name: BuildFlatpak
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
     - name: SetupFlatpak
       run: |
         flatpak remote-add --if-not-exists --user flathub https://flathub.org/repo/flathub.flatpakrepo
-        flatpak install flathub org.gnome.Platform//49 org.gnome.Sdk//50 -y
+        flatpak install flathub org.gnome.Platform//50 org.gnome.Sdk//50 -y
 
     - name: BuildFlatpak
       run: |

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,9 @@
 Gramps flatpak 6.0.8--1
   - update Gramps to 6.0.8
-  - add python-imagesize to deps
+  - add python-imagesize
   - update Gnome Platform to 50
+  - add GNU RCS
+  - add ttf-freefonts
 
 Gramps flatpak 6.0.7--1
   - update Gramps to 6.0.7

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Gramps flatpak 6.0.8--1
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts
+  - add python-fontconfig
 
 Gramps flatpak 6.0.7--1
   - update Gramps to 6.0.7

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,6 @@ Gramps flatpak 6.0.8--1
   - update Gramps to 6.0.8
   - add python-imagesize
   - update Gnome Platform to 50
-  - add GNU RCS with Ed
   - add ttf-freefonts
 
 Gramps flatpak 6.0.7--1

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,7 @@
 Gramps flatpak 6.1.0-beta1--1
   - update Gramps to 6.1.0-beta1
   - add Gramps 6.1 build dependencies pluggy, hatchling, pathspec, trove_classifiers
+  - add requests and certifi required dependencies for Gramps 6.1
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,7 @@ Gramps flatpak 6.0.8--1
   - update Gnome Platform to 50
   - add ttf-freefonts
   - add python-fontconfig
+  - add pycountry
 
 Gramps flatpak 6.0.7--1
   - update Gramps to 6.0.7

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,8 +2,7 @@ Gramps flatpak 6.1.0-beta1--1
   - update Gramps to 6.1.0-beta1
   - add Gramps 6.1 build dependencies pluggy, hatchling, pathspec, trove_classifiers
   - add requests and certifi required dependencies for Gramps 6.1
-  - add charset_normalizer as a required dependency for requests (above)
-  - add idna
+  - add charset_normalizer, idna, and urllib3 as a required dependency for requests (above)
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,6 @@
 Gramps flatpak 6.1.0-beta1--1
   - update Gramps to 6.1.0-beta1
+  - add Gramps 6.1 build dependencies pluggy, hatchling, pathspec
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,6 +1,6 @@
 Gramps flatpak 6.1.0-beta1--1
   - update Gramps to 6.1.0-beta1
-  - add Gramps 6.1 build dependencies pluggy, hatchling, pathspec
+  - add Gramps 6.1 build dependencies pluggy, hatchling, pathspec, trove_classifiers
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,7 +2,7 @@ Gramps flatpak 6.0.8--1
   - update Gramps to 6.0.8
   - add python-imagesize
   - update Gnome Platform to 50
-  - add GNU RCS
+  - add GNU RCS with Ed
   - add ttf-freefonts
 
 Gramps flatpak 6.0.7--1

--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,7 @@ Gramps flatpak 6.1.0-beta1--1
   - add Gramps 6.1 build dependencies pluggy, hatchling, pathspec, trove_classifiers
   - add requests and certifi required dependencies for Gramps 6.1
   - add charset_normalizer as a required dependency for requests (above)
+  - add idna
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts

--- a/ChangeLog
+++ b/ChangeLog
@@ -2,6 +2,7 @@ Gramps flatpak 6.1.0-beta1--1
   - update Gramps to 6.1.0-beta1
   - add Gramps 6.1 build dependencies pluggy, hatchling, pathspec, trove_classifiers
   - add requests and certifi required dependencies for Gramps 6.1
+  - add charset_normalizer as a required dependency for requests (above)
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,5 @@
-Gramps flatpak 6.0.8--1
-  - update Gramps to 6.0.8
+Gramps flatpak 6.1.0-beta1--1
+  - update Gramps to 6.1.0-beta1
   - add python-imagesize
   - update Gnome Platform to 50
   - add ttf-freefonts

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Gramps flatpak 6.0.8--1
+  - update Gramps to 6.0.8
+
 Gramps flatpak 6.0.7--1
   - update Gramps to 6.0.7
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,5 +1,7 @@
 Gramps flatpak 6.0.8--1
   - update Gramps to 6.0.8
+  - add python-imagesize to deps
+  - update Gnome Platform to 50
 
 Gramps flatpak 6.0.7--1
   - update Gramps to 6.0.7

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -68,13 +68,13 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
         sha256: 3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
-  # requests in required deps for Gramps 6.1 pyproject.toml
-  # most recent version as of 2026.04 is from 2026.03
-    - name: requestsDep
-      buildsystem: simple
-      build-commands:
-        - pip3 install --no-deps requests-*.whl
-      sources:
-        - type: file
-          url: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-          sha256: 4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+# requests in required deps for Gramps 6.1 pyproject.toml
+# most recent version as of 2026.04 is from 2026.03
+  - name: requestsDep
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps requests-*.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
+        sha256: 4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -1,0 +1,25 @@
+# Build dependencies for Gramps due to switch to pep517 in Gramps 6.1
+name: DepsBuild
+buildsystem: simple
+build-commands: []
+modules:
+# Gramps 6.1 requires hatchling for installation when tag --no-build-deps is used
+# hatchling most recent version as of 2026.04 is from 2026.02
+  - name: hatchling
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps hatchling-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+        sha256:   50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0
+# pathspec required for Gramps 6.1 module to build
+# pathspec most recent version as of 2026.04 is from 2026.01
+  - name: pathspec
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps pathspec-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
+        sha256:   fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -13,7 +13,7 @@ modules:
       - type: file
         only-arches: [x86_64]
         url: https://files.pythonhosted.org/packages/aa/fd/d0733fcb9086b8be4ebcfcda2d0312865d17d0d9884378b7cffb29d0763f/orjson-3.11.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-        sha256:  1469d254b9884f984026bd9b0fa5bbab477a4bfe558bba6848086f6d43eb5e73
+        sha256: 1469d254b9884f984026bd9b0fa5bbab477a4bfe558bba6848086f6d43eb5e73
       - type: file
         only-arches: [aarch64]
         url: https://files.pythonhosted.org/packages/55/b9/ae8d34899ff0c012039b5a7cb96a389b2476e917733294e498586b45472d/orjson-3.11.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
@@ -26,8 +26,8 @@ modules:
       - pip3 install --no-deps hatchling-*.whl
     sources:
       - type: file
-        url:  https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
-        sha256:   50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0
+        url: https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+        sha256: 50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0
 # pathspec required for Gramps 6.1 module to build
 # pathspec most recent version as of 2026.04 is from 2026.01
   - name: pathspec
@@ -36,8 +36,8 @@ modules:
       - pip3 install --no-deps pathspec-*.whl
     sources:
       - type: file
-        url:  https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
-        sha256:   fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
+        url: https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
+        sha256: fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
 # pluggy required for Gramps 6.1 module to build
 # most recent version as of 2026.04 is from 2025.05
   - name: pluggy
@@ -46,8 +46,8 @@ modules:
       - pip3 install --no-deps pluggy-*.whl
     sources:
       - type: file
-        url:  https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
-        sha256:   e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+        url: https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+        sha256: e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
 # trove_classifiers required for Gramps 6.1 module to build
 # most recent version as of 2026.04 is from 2026.01
   - name: trove_classifiers
@@ -56,8 +56,8 @@ modules:
       - pip3 install --no-deps trove_classifiers-*.whl
     sources:
       - type: file
-        url:  https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
-        sha256:   1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d
+        url: https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+        sha256: 1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d
 # certifi in required deps for pyproject from Gramps 6.1
 # most recent version as of 2026.04 is from 2026.04
   - name: certifi
@@ -66,15 +66,15 @@ modules:
       - pip3 install --no-deps certifi-*.whl
     sources:
       - type: file
-        url:  https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
-        sha256:   3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
+        url: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
+        sha256: 3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
   # requests in required deps for Gramps 6.1 pyproject.toml
   # most recent version as of 2026.04 is from 2026.03
-    - name: requests
+    - name: requestsDep
       buildsystem: simple
       build-commands:
         - pip3 install --no-deps requests-*.whl
       sources:
         - type: file
-          url:  https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
-          sha256:   4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a
+          url: https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
+          sha256: 4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -23,3 +23,13 @@ modules:
       - type: file
         url:  https://files.pythonhosted.org/packages/ef/3c/2c197d226f9ea224a9ab8d197933f9da0ae0aac5b6e0f884e2b8d9c8e9f7/pathspec-1.0.4-py3-none-any.whl
         sha256:   fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723
+# pluggy required for Gramps 6.1 module to build
+# most recent version as of 2026.04 is from 2025.05
+  - name: pluggy
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps pluggy-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
+        sha256:   e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -68,8 +68,8 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
         sha256: 3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
-# idna required for Gramps 6.1 module to build
-# idna most recent version as of 2026.04 is from 2026.04
+# requests in required deps for Gramps 6.1 pyproject.toml
+ # idna dep of requests most recent version as of 2026.04 is from 2026.04
   - name: idna
     buildsystem: simple
     build-commands:
@@ -78,7 +78,6 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl
         sha256: 60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67
-# requests in required deps for Gramps 6.1 pyproject.toml
  # charset normalizer is a required dep for requests
  # charset most recent version as of 2026.04 is from 2026.04
   - name: charset_normalizer
@@ -89,6 +88,15 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
         sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
+ # urllib3 req dep of requests, most recent version as of 2026.04 is from 2026.01
+  - name: urllib3
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps urllib3-*.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl
+        sha256: bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4
 # requests most recent version as of 2026.04 is from 2026.03
   - name: requests
     buildsystem: simple

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -68,6 +68,16 @@ modules:
       - type: file
         url: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
         sha256: 3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
+# idna required for Gramps 6.1 module to build
+# idna most recent version as of 2026.04 is from 2026.04
+  - name: idna
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps idna-*.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/53/b2/acc33950394b3becb2b664741a0c0889c7ef9f9ffbfa8d47eddb53a50abd/idna-3.12-py3-none-any.whl
+        sha256: 60ffaa1858fac94c9c124728c24fcde8160f3fb4a7f79aa8cdd33a9d1af60a67
 # requests in required deps for Gramps 6.1 pyproject.toml
  # charset normalizer is a required dep for requests
  # charset most recent version as of 2026.04 is from 2026.04

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -38,7 +38,7 @@ modules:
   - name: trove_classifiers
     buildsystem: simple
     build-commands:
-      -pip3 install --no-deps trove_classifiers-*.whl
+      - pip3 install --no-deps trove_classifiers-*.whl
     sources:
       - type: file
         url:  https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -69,8 +69,18 @@ modules:
         url: https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
         sha256: 3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
 # requests in required deps for Gramps 6.1 pyproject.toml
-# most recent version as of 2026.04 is from 2026.03
-  - name: requestsDep
+ # charset normalizer is a required dep for requests
+ # charset most recent version as of 2026.04 is from 2026.04
+  - name: charset_normalizer
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps charset_normalizer-*.whl
+    sources:
+      - type: file
+        url: https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl
+        sha256: 3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d
+# requests most recent version as of 2026.04 is from 2026.03
+  - name: requests
     buildsystem: simple
     build-commands:
       - pip3 install --no-deps requests-*.whl

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -33,3 +33,13 @@ modules:
       - type: file
         url:  https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl
         sha256:   e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746
+# trove_classifiers required for Gramps 6.1 module to build
+# most recent version as of 2026.04 is from 2026.01
+  - name: trove_classifiers
+    buildsystem: simple
+    build-commands:
+      -pip3 install --no-deps trove_classifiers-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
+        sha256:   1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d

--- a/DepsBuild.yml
+++ b/DepsBuild.yml
@@ -3,6 +3,21 @@ name: DepsBuild
 buildsystem: simple
 build-commands: []
 modules:
+# orjson in required deps for Gramps6.1 pyproject
+# most recent version as of 2025.11 is from 2025.10
+  - name: orjsonDependency
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps orjson-*.whl
+    sources:
+      - type: file
+        only-arches: [x86_64]
+        url: https://files.pythonhosted.org/packages/aa/fd/d0733fcb9086b8be4ebcfcda2d0312865d17d0d9884378b7cffb29d0763f/orjson-3.11.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
+        sha256:  1469d254b9884f984026bd9b0fa5bbab477a4bfe558bba6848086f6d43eb5e73
+      - type: file
+        only-arches: [aarch64]
+        url: https://files.pythonhosted.org/packages/55/b9/ae8d34899ff0c012039b5a7cb96a389b2476e917733294e498586b45472d/orjson-3.11.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
+        sha256: 38aa9e65c591febb1b0aed8da4d469eba239d434c218562df179885c94e1a3ad
 # Gramps 6.1 requires hatchling for installation when tag --no-build-deps is used
 # hatchling most recent version as of 2026.04 is from 2026.02
   - name: hatchling
@@ -43,3 +58,23 @@ modules:
       - type: file
         url:  https://files.pythonhosted.org/packages/bb/4a/2e5583e544bc437d5e8e54b47db87430df9031b29b48d17f26d129fa60c0/trove_classifiers-2026.1.14.14-py3-none-any.whl
         sha256:   1f9553927f18d0513d8e5ff80ab8980b8202ce37ecae0e3274ed2ef11880e74d
+# certifi in required deps for pyproject from Gramps 6.1
+# most recent version as of 2026.04 is from 2026.04
+  - name: certifi
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps certifi-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl
+        sha256:   3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a
+  # requests in required deps for Gramps 6.1 pyproject.toml
+  # most recent version as of 2026.04 is from 2026.03
+    - name: requests
+      buildsystem: simple
+      build-commands:
+        - pip3 install --no-deps requests-*.whl
+      sources:
+        - type: file
+          url:  https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl
+          sha256:   4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -6,7 +6,7 @@ build-commands: []
 modules:
 # GNU RCS, for archiving versions of trees, most recent version with tar.xz as of 2026.04 is from 2020.10--later version used tar.lz which failed to compile in flatpak
   - name: RCS
-    buildsystem: automake
+    buildsystem: autotools
     sources:
       - type: archive
         url:  https://ftp.gnu.org/gnu/rcs/rcs-5.10.0.tar.xz

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -1,4 +1,5 @@
 # Core dependencies for Gramps
+# some code adapted from AI (Grok) recommendations
 name: DepsCore
 buildsystem: simple
 build-commands: []
@@ -10,6 +11,18 @@ modules:
       - type: archive
         url:  https://ftp.gnu.org/gnu/rcs/rcs-5.10.0.tar.xz
         sha256:  3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5
+# ttf-freefonts recommended at Gramps 6.0.8 README
+  - name: ttf-freefonts
+    buildsystem: simple
+    build-commands:
+      - mkdir -p /app/share/fonts/truetype/freefont
+      - install -m 644 *.ttf /app/share/fonts/truetype/freefont/
+      - install -m 644 README /app/share/doc/gnu-freefont/ || true
+    sources:
+      - type: git
+        url:  https://github.com/pld-linux/fonts-TTF-freefont.git
+        tag:  auto/th/fonts-TTF-freefont-20120503-4
+        strip-components: 1
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -4,22 +4,6 @@ name: DepsCore
 buildsystem: simple
 build-commands: []
 modules:
-# GNU RCS, for archiving versions of trees
-# GNU RCS requires legacy "ed" editor to configure, remove both RCS and ed modules if RCS gets dropped
-# ed most recent version with tar.gz instead of tar.lz is from 2009.07
-  - name: ed-DepForRCS
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url:  https://ftp.gnu.org/gnu/ed/ed-1.4.tar.gz
-        sha256:  db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda
-# GNU RCS have to use older version for compiling and compatability issues (lz, some coding changes)
-  - name: RCS
-    buildsystem: autotools
-    sources:
-      - type: archive
-        url:  https://ftp.gnu.org/gnu/rcs/rcs-5.8.2.tar.gz
-        sha256:  ea00bd5e0d0317d3388dd78c9b3a9381d7d1cce59d686aec60f41eb633c693dc
 # ttf-freefonts recommended at Gramps 6.0.8 README
   - name: ttf-freefonts
     buildsystem: simple

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -7,7 +7,7 @@ modules:
 # GNU RCS, for archiving versions of trees
 # GNU RCS requires legacy "ed" editor to configure, remove both RCS and ed modules if RCS gets dropped
 # ed most recent version with tar.gz instead of tar.lz is from 2009.07
-- name: ed
+- name: ed-DepForRCS
   buildsystem: autotools
   sources:
     - type: archive

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -18,8 +18,8 @@ modules:
     buildsystem: autotools
     sources:
       - type: archive
-        url:  https://ftp.gnu.org/gnu/rcs/rcs-5.10.0.tar.xz
-        sha256:  3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5
+        url:  https://ftp.gnu.org/gnu/rcs/rcs-5.8.2.tar.gz
+        sha256:  ea00bd5e0d0317d3388dd78c9b3a9381d7d1cce59d686aec60f41eb633c693dc
 # ttf-freefonts recommended at Gramps 6.0.8 README
   - name: ttf-freefonts
     buildsystem: simple

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -12,10 +12,9 @@ modules:
       - install -m 644 *.ttf /app/share/fonts/truetype/freefont/
       - install -m 644 README /app/share/doc/gnu-freefont/ || true
     sources:
-      - type: git
-        url:  https://github.com/pld-linux/fonts-TTF-freefont.git
-        tag:  auto/th/fonts-TTF-freefont-20120503-4
-        strip-components: 1
+      - type: archive
+        url:  https://ftp.gnu.org/gnu/freefont/freefont-ttf-20051206.tar.gz
+        sha256:  247af4ab5be736df63d9572665ea341251e8afaf924f384ddcb18c3549113ed3
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -3,13 +3,13 @@ name: DepsCore
 buildsystem: simple
 build-commands: []
 modules:
-# GNU RCS, for archiving versions of trees, most recent version as of 2026.04 is from 2022.02
+# GNU RCS, for archiving versions of trees, most recent version with tar.xz as of 2026.04 is from 2020.10--later version used tar.lz which failed to compile in flatpak
   - name: RCS
     buildsystem: automake
     sources:
       - type: archive
-        url:  https://mirror.team-cymru.com/gnu/rcs/rcs-5.10.1.tar.lz
-        sha256:  43ddfe10724a8b85e2468f6403b6000737186f01e60e0bd62fde69d842234cc5
+        url:  https://ftp.gnu.org/gnu/rcs/rcs-5.10.0.tar.xz
+        sha256:  3a0d9f958c7ad303e475e8634654974edbe6deb3a454491f3857dc1889bac5c5
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -100,3 +100,12 @@ modules:
       - type: archive
         url: https://gitlab.gnome.org/GNOME/gspell/-/archive/1.14.0/gspell-1.14.0.tar.gz
         sha256: 6ff11258569227c4ef0eaed0524e0c9f84308d34f89fbc49e5d961cdd832ac6a
+# pycountry for internationalization, most recent version as of 2026.04 is from 2026.02
+  - name: pycountry
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps pycountry-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl
+        sha256:  115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -109,3 +109,13 @@ modules:
       - type: file
         url:  https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl
         sha256:  115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a
+# Gramps 6.1 requires hatchling for installation when tag --no-build-deps is used
+# hatchling most recent version as of 2026.04 is from 2026.02
+  - name: hatchling
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-deps hatchling-*.whl
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
+        sha256:   50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -4,7 +4,16 @@ name: DepsCore
 buildsystem: simple
 build-commands: []
 modules:
-# GNU RCS, for archiving versions of trees, most recent version with tar.xz as of 2026.04 is from 2020.10--later version used tar.lz which failed to compile in flatpak
+# GNU RCS, for archiving versions of trees
+# GNU RCS requires legacy "ed" editor to configure, remove both RCS and ed modules if RCS gets dropped
+# ed most recent version with tar.gz instead of tar.lz is from 2009.07
+- name: ed
+  buildsystem: autotools
+  sources:
+    - type: archive
+      url:  https://ftp.gnu.org/gnu/ed/ed-1.4.tar.gz
+      sha256:  db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda
+# GNU RCS most recent version with tar.xz as of 2026.04 is from 2020.10--later version used tar.lz which failed to compile in flatpak
   - name: RCS
     buildsystem: autotools
     sources:

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -3,6 +3,13 @@ name: DepsCore
 buildsystem: simple
 build-commands: []
 modules:
+# GNU RCS, for archiving versions of trees, most recent version as of 2026.04 is from 2022.02
+  - name: RCS
+    buildsystem: automake
+    sources:
+      - type: archive
+        url:  https://mirror.team-cymru.com/gnu/rcs/rcs-5.10.1.tar.lz
+        sha256:  43ddfe10724a8b85e2468f6403b6000737186f01e60e0bd62fde69d842234cc5
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -13,7 +13,7 @@ modules:
       - type: archive
         url:  https://ftp.gnu.org/gnu/ed/ed-1.4.tar.gz
         sha256:  db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda
-# GNU RCS most recent version with tar.xz as of 2026.04 is from 2020.10--later version used tar.lz which failed to compile in flatpak
+# GNU RCS have to use older version for compiling and compatability issues (lz, some coding changes)
   - name: RCS
     buildsystem: autotools
     sources:

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -15,6 +15,15 @@ modules:
       - type: archive
         url:  https://ftp.gnu.org/gnu/freefont/freefont-ttf-20051206.tar.gz
         sha256:  247af4ab5be736df63d9572665ea341251e8afaf924f384ddcb18c3549113ed3
+# python-fontconfig optional for symbols and reports, most recent version as of 2026.04 is from 2025.09
+  - name: python-fontconfig
+      buildsystem: simple
+      build-commands:
+        - pip3 install --no-build-isolation .
+    sources:
+      - type: archive
+        url:  https://files.pythonhosted.org/packages/20/59/99db03443f584b6d14bb635ef9f849dae7966792471dee9bf50ae2308f07/python_fontconfig-0.6.2.post1.tar.gz
+        sha256:   4837290305613710cf6c515db8923284da06e4f48a549d2fe8e2d4276aed3e73 
 # PILLOW for cropping images, latex support, and addons; most recent version as of 2025.03 is from 2025.01
   - name: PILLOWDependency
     buildsystem: simple

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -79,20 +79,6 @@ modules:
       - type: archive
         url:  https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs10060/ghostscript-10.06.0.tar.gz
         sha256:  5bd6da34794928cc7e616f288e32bd0be7f9a5ca2d3c206a0af2c19a4e3a318f
-# most recent version as of 2025.11 is from 2025.10
-  - name: orjsonDependency
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-deps orjson-*.whl
-    sources:
-      - type: file
-        only-arches: [x86_64]
-        url: https://files.pythonhosted.org/packages/aa/fd/d0733fcb9086b8be4ebcfcda2d0312865d17d0d9884378b7cffb29d0763f/orjson-3.11.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-        sha256:  1469d254b9884f984026bd9b0fa5bbab477a4bfe558bba6848086f6d43eb5e73
-      - type: file
-        only-arches: [aarch64]
-        url: https://files.pythonhosted.org/packages/55/b9/ae8d34899ff0c012039b5a7cb96a389b2476e917733294e498586b45472d/orjson-3.11.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl
-        sha256: 38aa9e65c591febb1b0aed8da4d469eba239d434c218562df179885c94e1a3ad
 # Gspell most recent version as of 2025.03 was from 2024.09
   - name: gspell
     buildsystem: meson
@@ -109,13 +95,3 @@ modules:
       - type: file
         url:  https://files.pythonhosted.org/packages/9c/42/7703bd45b62fecd44cd7d3495423097e2f7d28bc2e99e7c1af68892ab157/pycountry-26.2.16-py3-none-any.whl
         sha256:  115c4baf7cceaa30f59a4694d79483c9167dbce7a9de4d3d571c5f3ea77c305a
-# Gramps 6.1 requires hatchling for installation when tag --no-build-deps is used
-# hatchling most recent version as of 2026.04 is from 2026.02
-  - name: hatchling
-    buildsystem: simple
-    build-commands:
-      - pip3 install --no-deps hatchling-*.whl
-    sources:
-      - type: file
-        url:  https://files.pythonhosted.org/packages/d3/8a/44032265776062a89171285ede55a0bdaadc8ac00f27f0512a71a9e3e1c8/hatchling-1.29.0-py3-none-any.whl
-        sha256:   50af9343281f34785fab12da82e445ed987a6efb34fd8c2fc0f6e6630dbcc1b0

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -17,9 +17,9 @@ modules:
         sha256:  247af4ab5be736df63d9572665ea341251e8afaf924f384ddcb18c3549113ed3
 # python-fontconfig optional for symbols and reports, most recent version as of 2026.04 is from 2025.09
   - name: python-fontconfig
-      buildsystem: simple
-      build-commands:
-        - pip3 install --no-build-isolation .
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
     sources:
       - type: archive
         url:  https://files.pythonhosted.org/packages/20/59/99db03443f584b6d14bb635ef9f849dae7966792471dee9bf50ae2308f07/python_fontconfig-0.6.2.post1.tar.gz

--- a/DepsCore.yml
+++ b/DepsCore.yml
@@ -7,12 +7,12 @@ modules:
 # GNU RCS, for archiving versions of trees
 # GNU RCS requires legacy "ed" editor to configure, remove both RCS and ed modules if RCS gets dropped
 # ed most recent version with tar.gz instead of tar.lz is from 2009.07
-- name: ed-DepForRCS
-  buildsystem: autotools
-  sources:
-    - type: archive
-      url:  https://ftp.gnu.org/gnu/ed/ed-1.4.tar.gz
-      sha256:  db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda
+  - name: ed-DepForRCS
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url:  https://ftp.gnu.org/gnu/ed/ed-1.4.tar.gz
+        sha256:  db36da85ee1a9d8bafb4b041bd4c8c11becba0c43ec446353b67045de1634fda
 # GNU RCS most recent version with tar.xz as of 2026.04 is from 2020.10--later version used tar.lz which failed to compile in flatpak
   - name: RCS
     buildsystem: autotools

--- a/DepsImages.yml
+++ b/DepsImages.yml
@@ -30,7 +30,7 @@ modules:
   - name: python-imagesize
     buildsystem: simple
     build-commands:
-      - pip3 install --no-build-isolation .
+      - pip3 install --no-deps imagesize-*.whl
     sources:
       - type: file
         url:  https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl

--- a/DepsImages.yml
+++ b/DepsImages.yml
@@ -26,3 +26,12 @@ modules:
       - type: archive
         url:  https://gitlab.gnome.org/GNOME/gexiv2/-/archive/gexiv2-0.14.3/gexiv2-gexiv2-0.14.3.tar.gz
         sha256:  5a7ea82effa9c812ac1518a1b4a22a15035d721b0b30cd4b8303228fd5b38e3c
+    # imagesize most recent version as of 2026.04 was from 2026.03
+  - name: python-imagesize
+    buildsystem: simple
+    build-commands:
+      - pip3 install --no-build-isolation .
+    sources:
+      - type: file
+        url:  https://files.pythonhosted.org/packages/5f/53/fb7122b71361a0d121b669dcf3d31244ef75badbbb724af388948de543e2/imagesize-2.0.0-py2.py3-none-any.whl
+        sha256:  5667c5bbb57ab3f1fa4bc366f4fbc971db3d5ed011fd2715fd8001f782718d96

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The flatpak is available on flathub at https://flathub.org/apps/details/org.gram
 The Gramps flatpak contains dependencies and works with flathub runtimes to work independently regardless of the linux distribution.  There are also dependencies for some third party add-ons like Graphview and Network Chart.
 
 # List of Included Dependencies
-Dependencies confirmed in the Gnome flatpak platform (Gnome 50 as of Gramps 6.0.8--1 flatpak):
+Dependencies confirmed in the Gnome flatpak platform (Gnome 50 as of Gramps 6.1.0-beta1--1 flatpak):
 - python3
 - gtk
 - pygobject

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Dependencies added to the flatpak
 - networkx
 - python-imagesize
 - TTF-Freefonts
+- python-fontconfig
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
 
@@ -37,6 +38,6 @@ https://github.com/flathub/org.gramps_project.Gramps
 
 Also, the old version of Berkeley Database (BSDDB3) that was included with the Gramps 5.0 and 5.1 flatpaks was dropped starting with Gramps 5.2. An old archived flatpak with BSDDB3 is available at the gramps-project github https://github.com/gramps-project/flatpak/releases/tag/v5.1.6-1 to facilitate the conversion of old Gramps databases from BSDDB3 to the current SQLite.
 
-I repeatedly failed to get GNU RCS with Ed to compile into the flatpak. If anyone can get it to compile, you are welcome to submit a PR to https://github.com/gramps-project/flatpak
+In 2021, Gnu RCS 5.10.0 could be compiled into the flatpak. The newer tar.lz archives and some formatting issues now make RCS fail to compile.  If anyone can get it to compile into the Gramps flatpak, you are welcome to submit a PR to https://github.com/gramps-project/flatpak
 
 Please make regular full backups of your important genealogy files, and include any attached media files for your genealogy in your backups for your convenience.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Dependencies added to the flatpak
 - goocanvas
 - networkx
 - python-imagesize
-- GNU RCS with its Ed dependency
 - TTF-Freefonts
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
@@ -37,5 +36,7 @@ https://github.com/gramps-project/flatpak
 https://github.com/flathub/org.gramps_project.Gramps
 
 Also, the old version of Berkeley Database (BSDDB3) that was included with the Gramps 5.0 and 5.1 flatpaks was dropped starting with Gramps 5.2. An old archived flatpak with BSDDB3 is available at the gramps-project github https://github.com/gramps-project/flatpak/releases/tag/v5.1.6-1 to facilitate the conversion of old Gramps databases from BSDDB3 to the current SQLite.
+
+I repeatedly failed to get GNU RCS with Ed to compile into the flatpak. If anyone can get it to compile, you are welcome to submit a PR to https://github.com/gramps-project/flatpak
 
 Please make regular full backups of your important genealogy files, and include any attached media files for your genealogy in your backups for your convenience.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Dependencies added to the flatpak
 - python-imagesize
 - TTF-Freefonts
 - python-fontconfig
+- pycountry
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Dependencies added to the flatpak
 - goocanvas
 - networkx
 - python-imagesize
-- GNU RCS
+- GNU RCS with its Ed dependency
 - TTF-Freefonts
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Dependencies added to the flatpak
 - TTF-Freefonts
 - python-fontconfig
 - pycountry
+- requests with its charset_normalizer dependency
+- certifi
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Dependencies added to the flatpak
 - TTF-Freefonts
 - python-fontconfig
 - pycountry
-- requests with its charset_normalizer dependency
+- requests with its charset_normalizer, urllib3, and idna dependencies
 - certifi
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,14 @@ The flatpak is available on flathub at https://flathub.org/apps/details/org.gram
 The Gramps flatpak contains dependencies and works with flathub runtimes to work independently regardless of the linux distribution.  There are also dependencies for some third party add-ons like Graphview and Network Chart.
 
 # List of Included Dependencies
-Dependencies confirmed in the Gnome flatpak platform (Gnome 49 as of Gramps 6.0.5--2 flatpak):
+Dependencies confirmed in the Gnome flatpak platform (Gnome 50 as of Gramps 6.0.8--1 flatpak):
 - python3
 - gtk
 - pygobject
 - cairo
 - pango
 - pangocairo
+- librsvg2
 
 Dependencies added to the flatpak
 - orjson
@@ -25,6 +26,7 @@ Dependencies added to the flatpak
 - geocodeglib
 - goocanvas
 - networkx
+- python-imagesize
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Dependencies added to the flatpak
 - goocanvas
 - networkx
 - python-imagesize
+- GNU RCS
+- TTF-Freefonts
 
 To request another prerequisite be added to support another Gramps add-on, you can request it at the gramps project flatpak github.
 

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -63,9 +63,6 @@ modules:
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
-  #    - type: git
-  #      url: https://github.com/gramps-project/gramps.git
-  #      tag: v6.0.8
-       - type: archive
-         url:  https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.8.tar.gz
-         sha256:  f36069c71449b92636883f69addae38e76fa07ec37d9b3fcb5cac0b38390e314
+      - type: git
+        url: https://github.com/gramps-project/gramps.git
+        tag: v6.0.8

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -64,5 +64,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: git
-        url: https://github.com/gramps-project/gramps.git
-        tag: v6.0.8
+        url: https://github.com/hgohel/gramps.git
+        tag: 14183-gtk-label-as-string

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -64,5 +64,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: git
-        url: https://github.com/hgohel/gramps.git
-        tag: 14183-gtk-label-as-string
+        url: https://github.com/gramps-project/gramps.git
+        tag: v6.1.0-beta1

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -1,7 +1,7 @@
 app-id: org.gramps_project.Gramps
 # flatpak-builder will not take hyphen in com.gramps-project.Gramps
 runtime: org.gnome.Platform
-runtime-version: '49'
+runtime-version: '50'
 sdk: org.gnome.Sdk
 command: gramps
 # to force an archive flatpak to use system locale instead of English. Not needed for flathub packages.

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -64,4 +64,5 @@ modules:
       - pip3 install --no-build-isolation .
     sources:
       - type: git
-        url: https://github.com/gramps-project/gramps/tree/v6.0.8
+        url: https://github.com/gramps-project/gramps.git
+        tag: v6.0.8

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -49,6 +49,8 @@ cleanup:
   - /share/gir-1.0
   - /share/man
 modules:
+# manifest below is for Gramps 6.1 to build
+  - DepsBuild.yml
 # manifest below is for core Gramps dependencies
   - DepsCore.yml
 # manifest below is for image and exiv metadata

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -63,6 +63,9 @@ modules:
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
-      - type: git
-        url: https://github.com/gramps-project/gramps.git
-        tag: v6.0.8
+  #    - type: git
+  #      url: https://github.com/gramps-project/gramps.git
+  #      tag: v6.0.8
+       - type: archive
+         url:  https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.8.tar.gz
+         sha256:  f36069c71449b92636883f69addae38e76fa07ec37d9b3fcb5cac0b38390e314

--- a/org.gramps_project.Gramps.yml
+++ b/org.gramps_project.Gramps.yml
@@ -63,6 +63,5 @@ modules:
     build-commands:
       - pip3 install --no-build-isolation .
     sources:
-      - type: archive
-        url: https://github.com/gramps-project/gramps/archive/refs/tags/v6.0.7.tar.gz
-        sha256: 5b1d4d63f2abd072330a26d26db161a3c05f9a7d08bab07f29ef5647beafcb0a
+      - type: git
+        url: https://github.com/gramps-project/gramps/tree/v6.0.8


### PR DESCRIPTION
Gramps flatpak 6.1.0-beta1--1
  - update Gramps to 6.1.0-beta1
  - add Gramps 6.1 new build dependencies pluggy, hatchling, pathspec, trove_classifiers
  - add requests and certifi required dependencies for Gramps 6.1
  - add charset_normalizer, idna, and urllib3 as a required dependency for requests (above)
  - add python-imagesize
  - update Gnome Platform to 50
  - add ttf-freefonts
  - add python-fontconfig
  - add pycountry